### PR TITLE
Misc improvements

### DIFF
--- a/include/tiny-cuda-nn/common.h
+++ b/include/tiny-cuda-nn/common.h
@@ -80,6 +80,8 @@ enum class Activation {
 // Misc helpers //
 //////////////////
 
+uint32_t cuda_compute_capability(int device = 0);
+
 std::string to_lower(std::string str);
 std::string to_upper(std::string str);
 inline bool equals_case_insensitive(const std::string& str1, const std::string& str2) {

--- a/include/tiny-cuda-nn/cuda_graph.h
+++ b/include/tiny-cuda-nn/cuda_graph.h
@@ -33,6 +33,7 @@
 #include <tiny-cuda-nn/common.h>
 #include <cuda.h>
 
+
 TCNN_NAMESPACE_BEGIN
 
 class CudaGraph {

--- a/include/tiny-cuda-nn/encoding.h
+++ b/include/tiny-cuda-nn/encoding.h
@@ -78,6 +78,7 @@ public:
 	virtual uint32_t min_alignment() const = 0;
 
 	// By default, an encoding has no parameters
+	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override { }
 	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override { }
 	size_t n_params() const override { return 0; }
 

--- a/include/tiny-cuda-nn/network_with_input_encoding.h
+++ b/include/tiny-cuda-nn/network_with_input_encoding.h
@@ -143,6 +143,25 @@ public:
 		}
 	}
 
+	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override {
+		size_t offset = 0;
+		m_network->set_params(
+			params + offset,
+			inference_params + offset,
+			backward_params + offset,
+			gradients + offset
+		);
+		offset += m_network->n_params();
+
+		m_encoding->set_params(
+			params + offset,
+			inference_params + offset,
+			backward_params + offset,
+			gradients + offset
+		);
+		offset += m_encoding->n_params();
+	}
+
 	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override {
 		size_t offset = 0;
 		m_network->initialize_params(

--- a/include/tiny-cuda-nn/networks/cutlass_mlp.h
+++ b/include/tiny-cuda-nn/networks/cutlass_mlp.h
@@ -69,6 +69,7 @@ public:
 		bool compute_param_gradients = true
 	) override;
 
+	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override;
 	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override;
 
 	GPUMatrix<T, RM>& input_weight_matrix(bool inference) {

--- a/include/tiny-cuda-nn/networks/cutlass_resnet.h
+++ b/include/tiny-cuda-nn/networks/cutlass_resnet.h
@@ -66,6 +66,7 @@ public:
 		bool compute_param_gradients = true
 	) override;
 
+	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override;
 	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override;
 
 	GPUMatrix<T, RM>& input_weight_matrix(bool inference) {

--- a/include/tiny-cuda-nn/networks/fully_fused_mlp.h
+++ b/include/tiny-cuda-nn/networks/fully_fused_mlp.h
@@ -62,6 +62,7 @@ public:
 		bool compute_param_gradients = true
 	) override;
 
+	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override;
 	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override;
 
 	GPUMatrix<T, RM>& input_weight_matrix(WeightUsage usage) {

--- a/include/tiny-cuda-nn/object.h
+++ b/include/tiny-cuda-nn/object.h
@@ -59,6 +59,7 @@ class ParametricObject : public Object {
 public:
 	virtual ~ParametricObject() { }
 
+	virtual void set_params(PARAMS_T* params, PARAMS_T* inference_params, PARAMS_T* backward_params, PARAMS_T* gradients) = 0;
 	virtual void initialize_params(pcg32& rnd, float* params_full_precision, PARAMS_T* params, PARAMS_T* inference_params, PARAMS_T* backward_params, PARAMS_T* gradients, float scale = 1) = 0;
 	virtual size_t n_params() const = 0;
 

--- a/samples/mlp_learning_an_image.cu
+++ b/samples/mlp_learning_an_image.cu
@@ -94,32 +94,20 @@ __global__ void eval_image(uint32_t n_elements, cudaTextureObject_t texture, flo
 }
 
 int main(int argc, char* argv[]) {
-	if (!(__CUDACC_VER_MAJOR__ > 10 || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 2))) {
-		std::cout << "Turing Tensor Core operations must be compiled with CUDA 10.2 Toolkit or later." << std::endl;
-		return -1;
-	}
-
-	cudaDeviceProp props;
-
-	cudaError_t error = cudaGetDeviceProperties(&props, 0);
-	if (error != cudaSuccess) {
-		std::cout << "cudaGetDeviceProperties() returned an error: " << cudaGetErrorString(error) << std::endl;
-		return -1;
-	}
-
-	if (!((props.major * 10 + props.minor) >= 75)) {
-		std::cout << "Turing Tensor Core operations must be run on a machine with compute capability at least 75."
-					<< std::endl;
-		return -1;
-	}
-
-	if (argc < 2) {
-		std::cout << "USAGE: " << argv[0] << " " << "path-to-image.exr [path-to-optional-config.json]" << std::endl;
-		std::cout << "Sample EXR files are provided in 'data/images'." << std::endl;
-		return 0;
-	}
-
 	try {
+		uint32_t compute_capability = cuda_compute_capability();
+		if (compute_capability < MIN_GPU_ARCH) {
+			std::cerr
+				<< "Warning: Insufficient compute capability " << compute_capability << " detected. "
+				<< "This program was compiled for >=" << MIN_GPU_ARCH << " and may thus behave unexpectedly." << std::endl;
+		}
+
+		if (argc < 2) {
+			std::cout << "USAGE: " << argv[0] << " " << "path-to-image.exr [path-to-optional-config.json]" << std::endl;
+			std::cout << "Sample EXR files are provided in 'data/images'." << std::endl;
+			return 0;
+		}
+
 		json config = {
 			{"loss", {
 				{"otype", "RelativeL2"}

--- a/src/common.cu
+++ b/src/common.cu
@@ -37,14 +37,25 @@
 
 TCNN_NAMESPACE_BEGIN
 
+static_assert(
+	__CUDACC_VER_MAJOR__ > 10 || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 2),
+	"tiny-cuda-nn requires at least CUDA 10.2"
+);
+
+uint32_t cuda_compute_capability(int device) {
+	cudaDeviceProp props;
+	CUDA_CHECK_THROW(cudaGetDeviceProperties(&props, device));
+	return props.major * 10 + props.minor;
+}
+
 std::string to_lower(std::string str) {
-    std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) { return (char)std::tolower(c); });
-    return str;
+	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) { return (char)std::tolower(c); });
+	return str;
 }
 
 std::string to_upper(std::string str) {
-    std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) { return (char)std::toupper(c); });
-    return str;
+	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) { return (char)std::toupper(c); });
+	return str;
 }
 
 TCNN_NAMESPACE_END

--- a/src/cutlass_mlp.cu
+++ b/src/cutlass_mlp.cu
@@ -439,18 +439,25 @@ void CutlassMLP<T>::allocate_backward_buffers(uint32_t batch_size) {
 }
 
 template <typename T>
-void CutlassMLP<T>::initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale) {
+void CutlassMLP<T>::set_params(T* params, T* inference_params, T* backward_params, T* gradients) {
 	size_t current_pos = 0;
 	for (size_t i = 0; i < m_weight_matrices.size(); ++i) {
 		m_weight_matrices[i].set_data(params + current_pos);
 		m_weight_matrices_inference[i].set_data(inference_params + current_pos);
-		m_weight_matrices_full_precision[i].set_data(params_full_precision + current_pos);
 		m_gradient_matrices[i].set_data(gradients + current_pos);
-
 		current_pos += m_weight_matrices[i].n_elements();
 	}
+}
 
+template <typename T>
+void CutlassMLP<T>::initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale) {
+	set_params(params, inference_params, backward_params, gradients);
+
+	size_t current_pos = 0;
 	for (size_t i = 0; i < m_weight_matrices_full_precision.size(); ++i) {
+		m_weight_matrices_full_precision[i].set_data(params_full_precision + current_pos);
+		current_pos += m_weight_matrices_full_precision[i].n_elements();
+
 		if (m_activation == Activation::Sine) {
 			if (i == 0) {
 				m_weight_matrices_full_precision[i].initialize_siren_uniform_first(rnd, scale);

--- a/src/cutlass_resnet.cu
+++ b/src/cutlass_resnet.cu
@@ -383,18 +383,25 @@ void CutlassResNet<T, input_activation>::allocate_backward_buffers(uint32_t batc
 }
 
 template <typename T, Activation input_activation>
-void CutlassResNet<T, input_activation>::initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale) {
+void CutlassResNet<T, input_activation>::set_params(T* params, T* inference_params, T* backward_params, T* gradients) {
 	size_t current_pos = 0;
 	for (size_t i = 0; i < m_weight_matrices.size(); ++i) {
 		m_weight_matrices[i].set_data(params + current_pos);
 		m_weight_matrices_inference[i].set_data(inference_params + current_pos);
-		m_weight_matrices_full_precision[i].set_data(params_full_precision + current_pos);
 		m_gradient_matrices[i].set_data(gradients + current_pos);
 		current_pos += m_weight_matrices[i].n_elements();
 	}
+}
 
-	// Initialize the params
+template <typename T, Activation input_activation>
+void CutlassResNet<T, input_activation>::initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale) {
+	set_params(params, inference_params, backward_params, gradients);
+
+	size_t current_pos = 0;
 	for (size_t i = 0; i < m_weight_matrices_full_precision.size(); ++i) {
+		m_weight_matrices_full_precision[i].set_data(params_full_precision + current_pos);
+		current_pos += m_weight_matrices_full_precision[i].n_elements();
+
 		if (i == 0 && input_activation_value == Activation::Sine) {
 			m_weight_matrices_full_precision[i].initialize_siren_uniform_first(rnd, scale);
 		} else {

--- a/src/fully_fused_mlp.cu
+++ b/src/fully_fused_mlp.cu
@@ -945,19 +945,26 @@ void FullyFusedMLP<T, WIDTH>::allocate_backward_buffers(uint32_t batch_size) {
 }
 
 template <typename T, int WIDTH>
-void FullyFusedMLP<T, WIDTH>::initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale) {
+void FullyFusedMLP<T, WIDTH>::set_params(T* params, T* inference_params, T* backward_params, T* gradients) {
 	size_t current_pos = 0;
 	for (size_t i = 0; i < m_weight_matrices.size(); ++i) {
 		m_weight_matrices[i].set_data(params + current_pos);
 		m_weight_matrices_inference[i].set_data(inference_params + current_pos);
 		m_weight_matrices_backward[i].set_data((m_use_feedback_alignment ? backward_params : params) + current_pos);
-		m_weight_matrices_full_precision[i].set_data(params_full_precision + current_pos);
 		m_gradient_matrices[i].set_data(gradients + current_pos);
-
 		current_pos += m_weight_matrices[i].n_elements();
 	}
+}
 
+template <typename T, int WIDTH>
+void FullyFusedMLP<T, WIDTH>::initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale) {
+	set_params(params, inference_params, backward_params, gradients);
+
+	size_t current_pos = 0;
 	for (size_t i = 0; i < m_weight_matrices_full_precision.size(); ++i) {
+		m_weight_matrices_full_precision[i].set_data(params_full_precision + current_pos);
+		current_pos += m_weight_matrices_full_precision[i].n_elements();
+
 		if (m_activation == Activation::Sine) {
 			if (i == 0) {
 				m_weight_matrices_full_precision[i].initialize_siren_uniform_first(rnd, scale);

--- a/src/object.cu
+++ b/src/object.cu
@@ -36,7 +36,6 @@
 
 TCNN_NAMESPACE_BEGIN
 
-
 template <typename T>
 __global__ void one_hot_batched_kernel(const uint32_t num_elements, const uint32_t width, const uint32_t one_hot_dim, T* out, float scale) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
@@ -61,6 +60,5 @@ void mult(cudaStream_t stream, const uint32_t num_elements, T* inout, float fact
 
 template void mult(cudaStream_t stream, const uint32_t num_elements, float* inout, float factor);
 template void mult(cudaStream_t stream, const uint32_t num_elements, __half* inout, float factor);
-
 
 TCNN_NAMESPACE_END


### PR DESCRIPTION
- Extracts `set_params` from `initialize_params` to allow external frameworks (such as PyTorch) to supply their own parameters storage.
  - This is required for PyTorch / TensorFlow bindings. #14 
- Adds compile checks for CUDA 10.2 as well as runtime checks for compute capability