### PR TITLE
Support fp16 on compute capabilities 53, 60, and 62

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
             arch: 61
           - os: ubuntu-18.04
             cuda: "10.2"
+            arch: 53
+          - os: ubuntu-18.04
+            cuda: "10.2"
             arch: 37
     env:
       build_dir: "build"
@@ -74,6 +77,10 @@ jobs:
             visual_studio: "Visual Studio 16 2019"
             cuda: "11.5.1"
             arch: 61
+          - os: windows-2019
+            visual_studio: "Visual Studio 16 2019"
+            cuda: "11.5.1"
+            arch: 53
           - os: windows-2019
             visual_studio: "Visual Studio 16 2019"
             cuda: "11.5.1"

--- a/include/tiny-cuda-nn/common.h
+++ b/include/tiny-cuda-nn/common.h
@@ -49,17 +49,20 @@ TCNN_NAMESPACE_BEGIN
 
 static constexpr uint32_t MIN_GPU_ARCH = TCNN_MIN_GPU_ARCH;
 
-// TCNN has the following behavior depending on GPU arch
+// TCNN has the following behavior depending on GPU arch.
+// Refer to the first row of the table at the following URL for information about
+// when to pick fp16 versus fp32 precision for maximum performance.
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#arithmetic-instructions__throughput-native-arithmetic-instructions
 //
-// GPU Arch | FullyFusedMLP supported | CUTLASS SmArch supported |                          Precision
-// ---------|-------------------------|--------------------------|-----------------------------------
-//   80, 86 |                     yes |                       80 |                             __half
-//       75 |                     yes |                       75 |                             __half
-//       70 |                      no |                       70 |                             __half
-//       61 |                      no |                       70 | float (no tensor cores; slow fp16)
-//     <=60 |                      no |                       70 |           __half (no tensor cores)
+//  GPU Arch | FullyFusedMLP supported | CUTLASS SmArch supported |                 Precision
+// ----------|-------------------------|--------------------------|--------------------------
+//    80, 86 |                     yes |                       80 |                    __half
+//        75 |                     yes |                       75 |                    __half
+//        70 |                      no |                       70 |                    __half
+// 53-60, 62 |                      no |                       70 |  __half (no tensor cores)
+//  <=52, 61 |                      no |                       70 |   float (no tensor cores)
 
-using network_precision_t = std::conditional_t<MIN_GPU_ARCH == 61, float, __half>;
+using network_precision_t = std::conditional_t<MIN_GPU_ARCH == 61 || MIN_GPU_ARCH <= 52, float, __half>;
 
 // Optionally: set the precision to `float` to disable tensor cores and debug potential
 //             problems with mixed-precision training.

--- a/include/tiny-cuda-nn/common.h
+++ b/include/tiny-cuda-nn/common.h
@@ -51,14 +51,15 @@ static constexpr uint32_t MIN_GPU_ARCH = TCNN_MIN_GPU_ARCH;
 
 // TCNN has the following behavior depending on GPU arch
 //
-// GPU Arch | FullyFusedMLP supported | CUTLASS SmArch supported |               Precision
-// ---------|-------------------------|--------------------------|-------------------------
-//   80, 86 |                     yes |                       80 |                  __half
-//       75 |                     yes |                       75 |                  __half
-//       70 |                      no |                       70 |                  __half
-//      <70 |                      no |                       70 | float (no tensor cores)
+// GPU Arch | FullyFusedMLP supported | CUTLASS SmArch supported |                          Precision
+// ---------|-------------------------|--------------------------|-----------------------------------
+//   80, 86 |                     yes |                       80 |                             __half
+//       75 |                     yes |                       75 |                             __half
+//       70 |                      no |                       70 |                             __half
+//       61 |                      no |                       70 | float (no tensor cores; slow fp16)
+//     <=60 |                      no |                       70 |           __half (no tensor cores)
 
-using network_precision_t = std::conditional_t<MIN_GPU_ARCH < 70, float, __half>;
+using network_precision_t = std::conditional_t<MIN_GPU_ARCH == 61, float, __half>;
 
 // Optionally: set the precision to `float` to disable tensor cores and debug potential
 //             problems with mixed-precision training.

--- a/include/tiny-cuda-nn/cutlass_matmul.h
+++ b/include/tiny-cuda-nn/cutlass_matmul.h
@@ -86,7 +86,7 @@ using TypeCompute = std::conditional_t<std::is_same<network_precision_t, float>:
 
 template <typename T>
 using MMAOp = typename std::conditional<
-	std::is_same<T, float>::value,
+	std::is_same<T, float>::value || MIN_GPU_ARCH < 70,
 	cutlass::arch::OpClassSimt,
 	cutlass::arch::OpClassTensorOp
 >::type;
@@ -112,19 +112,19 @@ using FullLayerK = LayerConfig<cutlass::gemm::GemmShape<64, 64, 32>, cutlass::ge
 using LastLayerK = LayerConfig<cutlass::gemm::GemmShape<64, 64, 32>, cutlass::gemm::GemmShape<32, 32, 32>>;
 
 using FullLayer = typename std::conditional<
-	std::is_same<TypeCompute, float>::value,
+	std::is_same<MMAOp<network_precision_t>, cutlass::arch::OpClassSimt>::value,
 	LayerConfig<cutlass::gemm::GemmShape<128, 128, 8>, cutlass::gemm::GemmShape<32, 64, 8>>,
 	LayerConfig<cutlass::gemm::GemmShape<128, 128, 32>, cutlass::gemm::GemmShape<64, 64, 32>>
 >::type;
 
 using FullLayerPreReLU = typename std::conditional<
-	std::is_same<TypeCompute, float>::value,
+	std::is_same<MMAOp<network_precision_t>, cutlass::arch::OpClassSimt>::value,
 	LayerConfig<cutlass::gemm::GemmShape<128, 128, 8, true>, cutlass::gemm::GemmShape<32, 64, 8, true>>,
 	LayerConfig<cutlass::gemm::GemmShape<128, 128, 32, true>, cutlass::gemm::GemmShape<64, 64, 32, true>>
 >::type;
 
 using LastLayer = typename std::conditional<
-	std::is_same<TypeCompute, float>::value,
+	std::is_same<MMAOp<network_precision_t>, cutlass::arch::OpClassSimt>::value,
 	LayerConfig<cutlass::gemm::GemmShape<128, 128, 8>, cutlass::gemm::GemmShape<32, 64, 8>>,
 	typename std::conditional<
 		std::is_same<SmArch, cutlass::arch::Sm80>::value || std::is_same<SmArch, cutlass::arch::Sm75>::value,

--- a/include/tiny-cuda-nn/encodings/grid.h
+++ b/include/tiny-cuda-nn/encodings/grid.h
@@ -469,7 +469,7 @@ protected:
 template <typename T, uint32_t N_POS_DIMS=3, uint32_t N_FEATURES_PER_LEVEL=2>
 class GridEncodingTemplated : public GridEncoding<T> {
 public:
-#if TCNN_MIN_GPU_ARCH >= 60
+#if TCNN_MIN_GPU_ARCH >= 70
 	// The GPUs that we tested this on do not have an efficient 1D fp16
 	// atomicAdd feature. Thus, we accumulate gradients at fp32 if we're
 	// forced to use 1D atomicAdds. As soon as 2D or higher is possible,
@@ -477,7 +477,8 @@ public:
 	using grad_t = std::conditional_t<N_FEATURES_PER_LEVEL == 1, float, T>;
 #else
 	// atomicAdd(__half2) is only supported with compute capability 60 and above.
-	// Since atomicAdd(__half) is relatively slow, accumulate in fp32 instead.
+	// Since atomicAdd(__half) is relatively slow / doesn't exist for low compute
+	// capabilities, accumulate in fp32 instead.
 	using grad_t = float;
 #endif
 


### PR DESCRIPTION
This improves the performance by ~30% and reduces memory footprint significantly for GPUs with compute capability 53, 60, and 62.

Note that for compute capability 61 (GTX 1000 series) and <=52, the default remains fp32, because fp16 operations are significantly slower on those GPUs (or completely unavailable). See the [first row of this table listing fp16 vs. fp32 throughput](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#arithmetic-instructions__throughput-native-arithmetic-instructions).