### PR TITLE
Add support for row-major outputs of `GridEncoding`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-/build*
+build*
 /tmp
 /.vscode
 __pycache__
 .DS_Store
+*.egg-info

--- a/include/tiny-cuda-nn/config.h
+++ b/include/tiny-cuda-nn/config.h
@@ -25,7 +25,7 @@
 
 /** @file   config.h
  *  @author Thomas Müller, NVIDIA
- *  @brief  API interface to create everything needed for using the framework from
+ *  @brief  API to create everything needed for using the framework from
  *          a single json config.
  */
 

--- a/include/tiny-cuda-nn/encoding.h
+++ b/include/tiny-cuda-nn/encoding.h
@@ -77,6 +77,20 @@ public:
 	virtual void set_alignment(uint32_t alignment) = 0;
 	virtual uint32_t min_alignment() const = 0;
 
+	virtual bool supports_output_layout(MatrixLayout layout) const {
+		return layout == CM;
+	}
+
+	virtual void set_output_layout(MatrixLayout layout) {
+		if (layout == RM) {
+			throw std::runtime_error{"Encoding does not support row-major outputs."};
+		}
+	}
+
+	virtual MatrixLayout output_layout() const {
+		return CM;
+	}
+
 	// By default, an encoding has no parameters
 	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override { }
 	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override { }

--- a/include/tiny-cuda-nn/gpu_memory.h
+++ b/include/tiny-cuda-nn/gpu_memory.h
@@ -438,18 +438,26 @@ private:
 
 class BorrowedWorkspace {
 public:
+	BorrowedWorkspace() = default;
 	BorrowedWorkspace(Workspace* workspace) : m_workspace{workspace} {
 		m_workspace->borrow();
 	}
 
 	~BorrowedWorkspace() {
-		m_workspace->release();
+		if (m_workspace) {
+			m_workspace->release();
+		}
 	}
 
 	BorrowedWorkspace(const BorrowedWorkspace& other) = delete;
 
-	BorrowedWorkspace(BorrowedWorkspace&& other) {
+	BorrowedWorkspace& operator=(BorrowedWorkspace&& other) {
 		std::swap(m_workspace, other.m_workspace);
+		return *this;
+	}
+
+	BorrowedWorkspace(BorrowedWorkspace&& other) {
+		*this = std::move(other);
 	}
 
 	GPUMemory<uint8_t>& mem() {


### PR DESCRIPTION
This avoids a needless RM/CM conversion when the consumer (typically `NetworkWithInputEncoding`) can handle RM inputs. Consequently, the memory usage & performance of `GridEncoding` is improved. Other encodings are still to be experimented with.