### PR TITLE
Decouple `forward()` context from `Object`

### DIFF
--- a/include/tiny-cuda-nn/common.h
+++ b/include/tiny-cuda-nn/common.h
@@ -35,6 +35,8 @@
 #define TCNN_NAMESPACE_BEGIN namespace tcnn {
 #define TCNN_NAMESPACE_END }
 
+#include <tiny-cuda-nn/cpp_api.h>
+
 #include <array>
 #include <iostream>
 #include <sstream>

--- a/include/tiny-cuda-nn/cpp_api.h
+++ b/include/tiny-cuda-nn/cpp_api.h
@@ -32,6 +32,17 @@
 
 #include <json/json.hpp>
 
+#include <memory>
+
+namespace tcnn {
+	struct Context {
+		Context() = default;
+		virtual ~Context() {}
+		Context(const Context&) = delete;
+		Context(Context&&) = delete;
+	};
+}
+
 namespace tcnn { namespace cpp {
 
 using json = nlohmann::json;
@@ -41,14 +52,18 @@ enum EPrecision {
 	Fp16,
 };
 
+struct Context {
+	std::unique_ptr<tcnn::Context> ctx;
+};
+
 class Module {
 public:
 	Module(EPrecision output_precision) : m_output_precision{output_precision} {}
 	virtual ~Module() {}
 
 	virtual void inference(cudaStream_t stream, uint32_t n_elements, const float* input, void* output, void* params) = 0;
-	virtual void forward(cudaStream_t stream, uint32_t n_elements, const float* input, void* output, void* params, bool prepare_input_gradients) = 0;
-	virtual void backward(cudaStream_t stream, uint32_t n_elements, float* dL_dinput, const void* dL_doutput, void* dL_dparams, const float* input, const void* output, const void* params) = 0;
+	virtual Context forward(cudaStream_t stream, uint32_t n_elements, const float* input, void* output, void* params, bool prepare_input_gradients) = 0;
+	virtual void backward(cudaStream_t stream, const Context& ctx, uint32_t n_elements, float* dL_dinput, const void* dL_doutput, void* dL_dparams, const float* input, const void* output, const void* params) = 0;
 
 	virtual uint32_t n_input_dims() const = 0;
 

--- a/include/tiny-cuda-nn/network.h
+++ b/include/tiny-cuda-nn/network.h
@@ -58,15 +58,14 @@ public:
 		layer = std::min(layer, num_forward_activations()-1);
 		dimension = std::min(dimension, width(layer)-1);
 
-		this->forward(stream, input);
-		auto vals = forward_activations(layer);
+		auto ctx = this->forward(stream, input);
+		auto vals = forward_activations(*ctx, layer);
 		extract_dimension_pos_neg<PARAMS_T>(stream, output.n_elements(), dimension, width(layer), output.rows(), vals.first, vals.second, output.data());
-		this->forward_clear();
 	}
 
 	virtual uint32_t width(uint32_t layer) const = 0;
 	virtual uint32_t num_forward_activations() const = 0;
-	virtual std::pair<const PARAMS_T*, MatrixLayout> forward_activations(uint32_t layer) const = 0;
+	virtual std::pair<const PARAMS_T*, MatrixLayout> forward_activations(const Context& ctx, uint32_t layer) const = 0;
 };
 
 template <typename T>

--- a/include/tiny-cuda-nn/networks/cutlass_resnet.h
+++ b/include/tiny-cuda-nn/networks/cutlass_resnet.h
@@ -53,13 +53,11 @@ public:
 	void inference(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<float>& output) override;
 	void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_matrices = true) override;
 
-	void forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_matrices = false, bool prepare_input_gradients = false) override;
-	void forward_clear() override {
-		m_forward.clear();
-	}
+	std::unique_ptr<Context> forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_matrices = false, bool prepare_input_gradients = false) override;
 
 	void backward(
 		cudaStream_t stream,
+		const Context& ctx,
 		const GPUMatrixDynamic<T>& input,
 		const GPUMatrixDynamic<T>& output,
 		const GPUMatrixDynamic<T>& dL_doutput,
@@ -130,15 +128,18 @@ public:
 		return m_n_blocks * m_n_matrices_per_block + 1;
 	}
 
-	std::pair<const T*, MatrixLayout> forward_activations(uint32_t layer) const override {
-		if (m_forward.hidden.size() == 0) {
-			throw std::runtime_error{"Must call forward() before accessing activations."};
-		}
-		return {m_forward.hidden.at(layer).data(), CM};
+	std::pair<const T*, MatrixLayout> forward_activations(const Context& ctx, uint32_t layer) const override {
+		const auto& forward = dynamic_cast<const ForwardContext&>(ctx);
+		return {forward.hidden.at(layer).data(), CM};
 	}
 
 private:
-	void allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size);
+	struct ForwardContext : public Context {
+		std::vector<GPUMatrix<T>> hidden;
+		GPUMatrix<T> input;
+	};
+
+	std::unique_ptr<ForwardContext> allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size);
 
 	uint32_t m_n_matrices_per_block;
 	uint32_t m_input_width;
@@ -156,17 +157,6 @@ private:
 	cudaStream_t m_training_stream;
 	std::vector<cudaStream_t> m_training_splitk_streams;
 	std::vector<cudaEvent_t> m_training_splitk_events;
-
-	// Storage of forward pass data
-	struct {
-		std::vector<GPUMatrix<T>> hidden;
-		GPUMatrix<T> input;
-
-		void clear() {
-			hidden.clear();
-			input = GPUMatrix<T>{};
-		}
-	} m_forward;
 
 	// Storage of params
 	std::vector<GPUMatrix<T, RM>> m_weight_matrices;

--- a/include/tiny-cuda-nn/networks/fully_fused_mlp.h
+++ b/include/tiny-cuda-nn/networks/fully_fused_mlp.h
@@ -49,13 +49,11 @@ public:
 	void inference(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<float>& output) override;
 	void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_matrices = true) override;
 
-	void forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_matrices = false, bool prepare_input_gradients = false) override;
-	void forward_clear() override {
-		m_forward.clear();
-	}
+	std::unique_ptr<Context> forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_matrices = false, bool prepare_input_gradients = false) override;
 
 	void backward(
 		cudaStream_t stream,
+		const Context& ctx,
 		const GPUMatrixDynamic<T>& input,
 		const GPUMatrixDynamic<T>& output,
 		const GPUMatrixDynamic<T>& dL_doutput,
@@ -141,15 +139,18 @@ public:
 		return m_n_hidden_layers;
 	}
 
-	std::pair<const T*, MatrixLayout> forward_activations(uint32_t layer) const override {
-		if (m_forward.hidden.size() == 0) {
-			throw std::runtime_error{"Must call forward() before accessing activations."};
-		}
-		return {m_forward.hidden.at(layer).data(), CM};
+	std::pair<const T*, MatrixLayout> forward_activations(const Context& ctx, uint32_t layer) const override {
+		const auto& forward = dynamic_cast<const ForwardContext&>(ctx);
+		return {forward.hidden.at(layer).data(), CM};
 	}
 
 private:
-	void allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size);
+	struct ForwardContext : public Context {
+		std::vector<GPUMatrix<T>> hidden;
+		GPUMemoryArena::Allocation alloc;
+	};
+
+	std::unique_ptr<ForwardContext> allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size);
 
 	uint32_t m_n_hidden_layers;
 	uint32_t m_n_hidden_matmuls;
@@ -168,17 +169,6 @@ private:
 	// Streams and events
 	std::vector<cudaStream_t> m_training_splitk_streams;
 	std::vector<cudaEvent_t> m_training_splitk_events;
-
-	// Storage of forward pass data
-	struct {
-		std::vector<GPUMatrix<T>> hidden;
-		GPUMemoryArena::Allocation alloc;
-
-		void clear() {
-			hidden.clear();
-			alloc = {};
-		}
-	} m_forward;
 
 	// Storage of params
 	std::vector<GPUMatrix<T, RM>> m_weight_matrices;

--- a/include/tiny-cuda-nn/object.h
+++ b/include/tiny-cuda-nn/object.h
@@ -99,8 +99,6 @@ public:
 		return forward(nullptr, input, output, use_inference_matrices, prepare_input_gradients);
 	}
 
-	virtual void forward_clear() {}
-
 	virtual void backward(
 		cudaStream_t stream,
 		const Context& ctx,

--- a/include/tiny-cuda-nn/object.h
+++ b/include/tiny-cuda-nn/object.h
@@ -37,6 +37,8 @@
 
 #include <pcg32/pcg32.h>
 
+#include <memory>
+
 TCNN_NAMESPACE_BEGIN
 
 using json = nlohmann::json;
@@ -81,26 +83,27 @@ public:
 		inference(nullptr, input, output);
 	}
 
-	virtual void forward(
+	virtual std::unique_ptr<Context> forward(
 		cudaStream_t stream,
 		const GPUMatrixDynamic<T>& input,
 		GPUMatrixDynamic<COMPUTE_T>* output = nullptr,
 		bool use_inference_matrices = false,
 		bool prepare_input_gradients = false
 	) = 0;
-	void forward(
+	std::unique_ptr<Context> forward(
 		const GPUMatrixDynamic<T>& input,
 		GPUMatrixDynamic<COMPUTE_T>* output = nullptr,
 		bool use_inference_matrices = false,
 		bool prepare_input_gradients = false
 	) {
-		forward(nullptr, input, output, use_inference_matrices, prepare_input_gradients);
+		return forward(nullptr, input, output, use_inference_matrices, prepare_input_gradients);
 	}
 
 	virtual void forward_clear() {}
 
 	virtual void backward(
 		cudaStream_t stream,
+		const Context& ctx,
 		const GPUMatrixDynamic<T>& input,
 		const GPUMatrixDynamic<COMPUTE_T>& output,
 		const GPUMatrixDynamic<COMPUTE_T>& dL_doutput,
@@ -109,6 +112,7 @@ public:
 		bool compute_param_gradients = true
 	) = 0;
 	void backward(
+		const Context& ctx,
 		const GPUMatrixDynamic<T>& input,
 		const GPUMatrixDynamic<COMPUTE_T>& output,
 		const GPUMatrixDynamic<COMPUTE_T>& dL_doutput,

--- a/src/cutlass_mlp.cu
+++ b/src/cutlass_mlp.cu
@@ -402,12 +402,10 @@ void CutlassMLP<T>::backward(
 			cudaStreamWaitEvent(stream, event, 0);
 		}
 	}
-
-	forward_clear();
 }
 
 template <typename T>
-std::unique_ptr<CutlassMLP<T>::ForwardContext> CutlassMLP<T>::allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size) {
+std::unique_ptr<typename CutlassMLP<T>::ForwardContext> CutlassMLP<T>::allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size) {
 	auto forward = std::make_unique<ForwardContext>();
 
 	forward->hidden.resize(num_forward_activations());

--- a/src/cutlass_mlp.cu
+++ b/src/cutlass_mlp.cu
@@ -211,7 +211,7 @@ void CutlassMLP<T>::inference_mixed_precision(cudaStream_t stream, const GPUMatr
 }
 
 template <typename T>
-void CutlassMLP<T>::forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output, bool use_inference_matrices, bool prepare_input_gradients) {
+std::unique_ptr<Context> CutlassMLP<T>::forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output, bool use_inference_matrices, bool prepare_input_gradients) {
 	// Various error checks
 	if (input.m() != m_input_width) {
 		throw std::runtime_error(std::string("Input has incorrect width: ") + std::to_string(input.m()) + "!=" + std::to_string(m_input_width));
@@ -228,12 +228,12 @@ void CutlassMLP<T>::forward(cudaStream_t stream, const GPUMatrixDynamic<T>& inpu
 	// If there are no hidden layers, the network is just a simple matmul. No tmp buffers required
 	if (output && m_n_hidden_layers == 0) {
 		compute_layer<LastLayer>(stream, false, m_output_activation, input_weight_matrix(use_inference_matrices), input, *output, *output);
-		return;
+		return std::make_unique<ForwardContext>(); // Nothing to save -- empty context
 	}
 
 	// Make sure our temporary buffers have the correct size for the given batch size
 	uint32_t batch_size = input.n();
-	allocate_forward_buffers(stream, batch_size);
+	auto forward = allocate_forward_buffers(stream, batch_size);
 
 	// Run the actual network
 	uint32_t tmp_idx = 0;
@@ -244,8 +244,8 @@ void CutlassMLP<T>::forward(cudaStream_t stream, const GPUMatrixDynamic<T>& inpu
 		m_activation,
 		input_weight_matrix(use_inference_matrices),
 		input,
-		m_forward.hidden.at(tmp_idx),
-		m_can_fuse_activation ? m_forward.hidden.at(tmp_idx) : m_forward.hidden.at(tmp_idx+1)
+		forward->hidden.at(tmp_idx),
+		m_can_fuse_activation ? forward->hidden.at(tmp_idx) : forward->hidden.at(tmp_idx+1)
 	);
 	tmp_idx += fused ? 1 : 2;
 
@@ -256,21 +256,24 @@ void CutlassMLP<T>::forward(cudaStream_t stream, const GPUMatrixDynamic<T>& inpu
 			false,
 			m_activation,
 			weight_matrix_at(use_inference_matrices, i),
-			m_forward.hidden.at(tmp_idx-1),
-			m_forward.hidden.at(tmp_idx),
-			m_can_fuse_activation ? m_forward.hidden.at(tmp_idx) : m_forward.hidden.at(tmp_idx+1)
+			forward->hidden.at(tmp_idx-1),
+			forward->hidden.at(tmp_idx),
+			m_can_fuse_activation ? forward->hidden.at(tmp_idx) : forward->hidden.at(tmp_idx+1)
 		);
 		tmp_idx += fused ? 1 : 2;
 	}
 
 	if (output) {
-		compute_layer<LastLayer>(stream, false, m_output_activation, output_weight_matrix(use_inference_matrices), m_forward.hidden.at(tmp_idx-1), *output, *output);
+		compute_layer<LastLayer>(stream, false, m_output_activation, output_weight_matrix(use_inference_matrices), forward->hidden.at(tmp_idx-1), *output, *output);
 	}
+
+	return forward;
 }
 
 template <typename T>
 void CutlassMLP<T>::backward(
 	cudaStream_t stream,
+	const Context& ctx,
 	const GPUMatrixDynamic<T>& input,
 	const GPUMatrixDynamic<T>& output,
 	const GPUMatrixDynamic<T>& dL_doutput,
@@ -278,10 +281,6 @@ void CutlassMLP<T>::backward(
 	bool use_inference_matrices,
 	bool compute_param_gradients
 ) {
-	if (m_n_hidden_layers > 0 && m_forward.hidden.size() == 0) {
-		throw std::runtime_error{"Must call forward() before calling backward()."};
-	}
-
 	if (dL_doutput.m() != m_padded_output_width) {
 		throw std::runtime_error(std::string("Output gradients have incorrect width (must be padded): ") + std::to_string(dL_doutput.m()) + "!=" + std::to_string(m_padded_output_width));
 	}
@@ -307,6 +306,8 @@ void CutlassMLP<T>::backward(
 	// - RELU: pre_activation_gradinet = post_activation_gradient if val > 0 else 0
 
 	{
+		const auto& forward = dynamic_cast<const ForwardContext&>(ctx);
+
 		int split_k_factor = batch_size / std::min((uint32_t)(1 << 12), batch_size);
 
 		const GPUMatrixDynamic<T>& tmp_dL_doutput = m_output_activation == Activation::None ? dL_doutput : backward_output_tmp;
@@ -342,16 +343,16 @@ void CutlassMLP<T>::backward(
 			cudaStreamWaitEvent(m_training_splitk_streams.at(backward_tmp_idx), m_training_splitk_events.at(backward_tmp_idx), 0);
 
 			// Compute weight gradients
-			fc_multiply_split_k<LastLayerK>(m_training_splitk_streams.at(backward_tmp_idx), tmp_dL_doutput, m_forward.hidden.at(tmp_idx).transposed(), output_gradient_matrix(), split_k_factor);
+			fc_multiply_split_k<LastLayerK>(m_training_splitk_streams.at(backward_tmp_idx), tmp_dL_doutput, forward.hidden.at(tmp_idx).transposed(), output_gradient_matrix(), split_k_factor);
 
 			cudaEventRecord(m_training_splitk_events.at(backward_tmp_idx), m_training_splitk_streams.at(backward_tmp_idx));
 		}
 
 		if (!m_can_fuse_activation) {
 			fc_multiply<FullLayer>(stream, output_weight_matrix(use_inference_matrices).transposed(), tmp_dL_doutput, backward_tmp.at(backward_tmp_idx));
-			activation_backward_gpu(stream, m_activation, m_forward.hidden.at(tmp_idx-1), backward_tmp.at(backward_tmp_idx));
+			activation_backward_gpu(stream, m_activation, forward.hidden.at(tmp_idx-1), backward_tmp.at(backward_tmp_idx));
 		} else {
-			fc_multiply<FullLayer>(stream, output_weight_matrix(use_inference_matrices).transposed(), tmp_dL_doutput, m_forward.hidden.at(tmp_idx), backward_tmp.at(backward_tmp_idx), m_activation, true);
+			fc_multiply<FullLayer>(stream, output_weight_matrix(use_inference_matrices).transposed(), tmp_dL_doutput, forward.hidden.at(tmp_idx), backward_tmp.at(backward_tmp_idx), m_activation, true);
 		}
 
 		tmp_idx -= m_can_fuse_activation ? 1 : 2;
@@ -364,15 +365,15 @@ void CutlassMLP<T>::backward(
 			if (compute_param_gradients) {
 				cudaEventRecord(m_training_splitk_events.at(backward_tmp_idx), stream);
 				cudaStreamWaitEvent(m_training_splitk_streams.at(backward_tmp_idx), m_training_splitk_events.at(backward_tmp_idx), 0);
-				fc_multiply_split_k<FullLayerK>(m_training_splitk_streams.at(backward_tmp_idx), backward_tmp.at(backward_tmp_idx-1), m_forward.hidden.at(tmp_idx).transposed(), gradient_matrix_at(matrix_idx), split_k_factor);
+				fc_multiply_split_k<FullLayerK>(m_training_splitk_streams.at(backward_tmp_idx), backward_tmp.at(backward_tmp_idx-1), forward.hidden.at(tmp_idx).transposed(), gradient_matrix_at(matrix_idx), split_k_factor);
 				cudaEventRecord(m_training_splitk_events.at(backward_tmp_idx), m_training_splitk_streams.at(backward_tmp_idx));
 			}
 
 			if (!m_can_fuse_activation) {
 				fc_multiply<FullLayer>(stream, weight_matrix_at(use_inference_matrices, matrix_idx).transposed(), backward_tmp.at(backward_tmp_idx-1), backward_tmp.at(backward_tmp_idx));
-				activation_backward_gpu(stream, m_activation, m_forward.hidden.at(tmp_idx-1), backward_tmp.at(backward_tmp_idx));
+				activation_backward_gpu(stream, m_activation, forward.hidden.at(tmp_idx-1), backward_tmp.at(backward_tmp_idx));
 			} else {
-				fc_multiply<FullLayer>(stream, weight_matrix_at(use_inference_matrices, matrix_idx).transposed(), backward_tmp.at(backward_tmp_idx-1), m_forward.hidden.at(tmp_idx), backward_tmp.at(backward_tmp_idx), m_activation, true);
+				fc_multiply<FullLayer>(stream, weight_matrix_at(use_inference_matrices, matrix_idx).transposed(), backward_tmp.at(backward_tmp_idx-1), forward.hidden.at(tmp_idx), backward_tmp.at(backward_tmp_idx), m_activation, true);
 			}
 
 			tmp_idx -= m_can_fuse_activation ? 1 : 2;
@@ -406,11 +407,15 @@ void CutlassMLP<T>::backward(
 }
 
 template <typename T>
-void CutlassMLP<T>::allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size) {
-	m_forward.hidden.resize(num_forward_activations());
+std::unique_ptr<CutlassMLP<T>::ForwardContext> CutlassMLP<T>::allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size) {
+	auto forward = std::make_unique<ForwardContext>();
+
+	forward->hidden.resize(num_forward_activations());
 	for (uint32_t i = 0; i < num_forward_activations(); ++i) {
-		m_forward.hidden[i] = GPUMatrix<T>{m_network_width, batch_size, stream};
+		forward->hidden[i] = GPUMatrix<T>{m_network_width, batch_size, stream};
 	}
+
+	return forward;
 }
 
 template <typename T>

--- a/src/cutlass_resnet.cu
+++ b/src/cutlass_resnet.cu
@@ -344,12 +344,10 @@ void CutlassResNet<T, input_activation>::backward(
 			cudaStreamWaitEvent(stream, event, 0);
 		}
 	}
-
-	forward_clear();
 }
 
 template <typename T, Activation input_activation>
-std::unique_ptr<CutlassResNet<T, input_activation>::ForwardContext> CutlassResNet<T, input_activation>::allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size) {
+std::unique_ptr<typename CutlassResNet<T, input_activation>::ForwardContext> CutlassResNet<T, input_activation>::allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size) {
 	auto forward = std::make_unique<ForwardContext>();
 
 	forward->input = GPUMatrix<T>{m_network_width, batch_size, stream};

--- a/src/fully_fused_mlp.cu
+++ b/src/fully_fused_mlp.cu
@@ -939,12 +939,10 @@ void FullyFusedMLP<T, WIDTH>::backward(
 			cudaStreamWaitEvent(stream, event, 0);
 		}
 	}
-
-	forward_clear();
 }
 
 template <typename T, int WIDTH>
-std::unique_ptr<FullyFusedMLP<T, WIDTH>::ForwardContext> FullyFusedMLP<T, WIDTH>::allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size) {
+std::unique_ptr<typename FullyFusedMLP<T, WIDTH>::ForwardContext> FullyFusedMLP<T, WIDTH>::allocate_forward_buffers(cudaStream_t stream, uint32_t batch_size) {
 	auto forward = std::make_unique<ForwardContext>();
 
 	// Use GPUMatrixBase::allocate_shared_memory to ensure the matrices occupy contiguous memory.


### PR DESCRIPTION
Abstract
---

So far, __tiny-cuda-nn__ implicity assumed that each `model->forward()` call would be paired with a single `model->backward()` call in that order and with no other calls inbetween, which was inflexible at best and error prone at worst.

Due to the recently added `GPUMemoryArena`, fixing this legacy behavior is now surprisingly simple. Wider PyTorch compatibility (#39) is just the icing on the cake.

Fixes #39 


What's changed?
---

`DifferentiableObject::forward()` now returns an opaque context that must be passed to the corresponding `DifferentiableObject::backward()` call to compute gradients. See the implementation of the `Trainer` class for an example.

Multiple such contexts can exist in parallel, so there is no requirement on the order of these calls or on their multiplicity.