### PR TITLE
Several PyTorch-related fixes

### DIFF
--- a/include/tiny-cuda-nn/object.h
+++ b/include/tiny-cuda-nn/object.h
@@ -141,8 +141,8 @@ public:
 		// Set "loss gradient" at network outputs to 1 at the chosen dimension and 0 elsewhere.
 		one_hot_batched(stream, output.n_elements(), padded_output_width(), dim, d_doutput.data(), backprop_scale);
 
-		forward(stream, input, &output, true /* inference matrices */, true /* prep forward buffers for input gradients */);
-		backward(stream, input, output, d_doutput, &d_dinput, true /* inference matrices */, false /* no param gradients */);
+		auto ctx = forward(stream, input, &output, true /* inference matrices */, true /* prep forward buffers for input gradients */);
+		backward(stream, *ctx, input, output, d_doutput, &d_dinput, true /* inference matrices */, false /* no param gradients */);
 
 		mult(stream, d_dinput.n_elements(), d_dinput.data(), 1.0f / backprop_scale);
 	}

--- a/samples/mlp_learning_an_image_pytorch.py
+++ b/samples/mlp_learning_an_image_pytorch.py
@@ -29,11 +29,8 @@
 
 import argparse
 import commentjson as json
-import glob
 import numpy as np
 import os
-import PIL.Image
-PIL.Image.MAX_IMAGE_PIXELS = 10000000000
 import sys
 import torch
 import time


### PR DESCRIPTION
- Fixes the issue https://github.com/NVlabs/tiny-cuda-nn/issues/14#issuecomment-1039548074 mentioned by @MultiPath
- Improves/stabilizes performance by using a custom CUDA stream rather than the PyTorch-provided one (which can be the blocking global stream)
- Removes the PyEXR / OpenEXR / PIL dependencies by switching to imageio