### PR TITLE
Always expose fp32 encodings in addition to fp16

### DIFF
--- a/bindings/torch/setup.py
+++ b/bindings/torch/setup.py
@@ -70,7 +70,7 @@ if torch.cuda.is_available():
 	bindings_dir = os.path.dirname(__file__)
 	root_dir = os.path.abspath(os.path.join(bindings_dir, "../.."))
 	source_files = [
-		"tinycudann/torch_bindings.cpp",
+		"tinycudann/bindings.cpp",
 		"../../src/cpp_api.cu",
 		"../../src/common.cu",
 		"../../src/common_device.cu",

--- a/bindings/torch/tinycudann/__init__.py
+++ b/bindings/torch/tinycudann/__init__.py
@@ -6,6 +6,6 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-from tinycudann.ops import NetworkWithInputEncoding, Network, Encoding
+from tinycudann.modules import NetworkWithInputEncoding, Network, Encoding
 
 __all__ = ["NetworkWithInputEncoding", "Network", "Encoding"]

--- a/bindings/torch/tinycudann/bindings.cpp
+++ b/bindings/torch/tinycudann/bindings.cpp
@@ -77,8 +77,8 @@ public:
 	: Module{tcnn::cpp::create_network(n_input_dims, n_output_dims, network)} {}
 
 	// Helper constructor to create a Encoding module
-	Module(uint32_t n_input_dims, const nlohmann::json& encoding)
-	: Module{tcnn::cpp::create_encoding(n_input_dims, encoding)} {}
+	Module(uint32_t n_input_dims, const nlohmann::json& encoding, tcnn::cpp::EPrecision requested_precision)
+	: Module{tcnn::cpp::create_encoding(n_input_dims, encoding, requested_precision)} {}
 
 	std::tuple<tcnn::cpp::Context, torch::Tensor> fwd(torch::Tensor input, torch::Tensor params) {
 		// Check for correct types
@@ -212,6 +212,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 		.export_values()
 		;
 
+	m.def("preferred_precision", &tcnn::cpp::preferred_precision);
+
 	// Encapsulates an abstract context of an operation
 	// (commonly the forward pass) to be passed on to other
 	// operations (commonly the backward pass).
@@ -234,9 +236,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 			py::arg("n_input_dims"), py::arg("n_output_dims"), py::arg("network_config")
 		)
 		.def(
-			py::init<uint32_t, const nlohmann::json&>(),
+			py::init<uint32_t, const nlohmann::json&, tcnn::cpp::EPrecision>(),
 			"Constructor for just the Encoding",
-			py::arg("n_input_dims"), py::arg("encoding_config")
+			py::arg("n_input_dims"), py::arg("encoding_config"), py::arg("precision")=tcnn::cpp::preferred_precision()
 		)
 		.def("fwd", &Module::fwd)
 		.def("bwd", &Module::bwd)

--- a/bindings/torch/tinycudann/modules.py
+++ b/bindings/torch/tinycudann/modules.py
@@ -12,7 +12,6 @@ from tinycudann_bindings import _C
 class _module_func(torch.autograd.Function):
 	@staticmethod
 	def forward(ctx, native_tcnn_module, input, params, loss_scale):
-		# params is just a dummy param for autograd, we got an internal pointer in native_tcnn_module
 		native_ctx, output = native_tcnn_module.fwd(input, params)
 		ctx.save_for_backward(input, params, output)
 		ctx.native_tcnn_module = native_tcnn_module
@@ -66,36 +65,117 @@ class Module(torch.nn.Module):
 		self.native_tcnn_module = self._native_tcnn_module()
 
 class NetworkWithInputEncoding(Module):
+	"""
+	Input encoding, followed by a neural network.
+
+	This module is more efficient than invoking individual `Encoding`
+	and `Network` modules in sequence.
+
+	Takes a `torch.float` input tensor of shape `[:, n_input_dims]` and maps
+	it to a tensor of shape `[:, n_output_dims]`.
+
+	The output tensor can be either of type `torch.float` or `torch.half`,
+	depending on which performs better on the system.
+
+	Parameters
+	----------
+	n_input_dims : `int`
+		Determines the shape of input tensors as `[:, n_input_dims]`
+	n_output_dims : `int`
+		Determines the shape of output tensors as `[:, n_output_dims]`
+	encoding_config: `dict`
+		Configures the encoding. Possible configurations are documented at
+		https://github.com/NVlabs/tiny-cuda-nn/blob/master/DOCUMENTATION.md
+	network_config: `dict`
+		Configures the neural network. Possible configurations are documented at
+		https://github.com/NVlabs/tiny-cuda-nn/blob/master/DOCUMENTATION.md
+	seed: `int`
+		Seed for pseudorandom parameter initialization
+	"""
 	def __init__(self, n_input_dims, n_output_dims, encoding_config, network_config, seed=1337):
 		self.n_input_dims = n_input_dims
 		self.n_output_dims = n_output_dims
 		self.encoding_config = encoding_config
 		self.network_config = network_config
 
-		super(NetworkWithInputEncoding, self).__init__()
+		super(NetworkWithInputEncoding, self).__init__(seed=seed)
 
 	def _native_tcnn_module(self):
 		return _C.Module(self.n_input_dims, self.n_output_dims, self.encoding_config, self.network_config)
 
 class Network(Module):
+	"""
+	Neural network.
+
+	Takes a `torch.float` input tensor of shape `[:, n_input_dims]` and maps
+	it to a tensor of shape `[:, n_output_dims]`.
+
+	The output tensor can be either of type `torch.float` or `torch.half`,
+	depending on which performs better on the system.
+
+	Parameters
+	----------
+	n_input_dims : `int`
+		Determines the shape of input tensors as `[:, n_input_dims]`
+	n_output_dims : `int`
+		Determines the shape of output tensors as `[:, n_output_dims]`
+	network_config: `dict`
+		Configures the neural network. Possible configurations are documented at
+		https://github.com/NVlabs/tiny-cuda-nn/blob/master/DOCUMENTATION.md
+	seed: `int`
+		Seed for pseudorandom parameter initialization
+	"""
 	def __init__(self, n_input_dims, n_output_dims, network_config, seed=1337):
 		self.n_input_dims = n_input_dims
 		self.n_output_dims = n_output_dims
 		self.network_config = network_config
 
-		super(Network, self).__init__()
+		super(Network, self).__init__(seed=seed)
 
 	def _native_tcnn_module(self):
 		return _C.Module(self.n_input_dims, self.n_output_dims, self.network_config)
 
 class Encoding(Module):
-	def __init__(self, n_input_dims, encoding_config, seed=1337):
+	"""
+	Input encoding to a neural network.
+
+	Takes a `torch.float` input tensor of shape `[:, n_input_dims]` and maps
+	it to a `dtype` tensor of shape `[:, self.n_output_dims]`, where
+	`self.n_output_dims` depends on `n_input_dims` and the configuration
+	`encoding_config`.
+
+	Parameters
+	----------
+	n_input_dims : `int`
+		Determines the shape of input tensors as `[:, n_input_dims]`
+	encoding_config: `dict`
+		Configures the encoding. Possible configurations are documented at
+		https://github.com/NVlabs/tiny-cuda-nn/blob/master/DOCUMENTATION.md
+	seed: `int`
+		Seed for pseudorandom parameter initialization
+	dtype: `torch.dtype`
+		Precision of the output tensor and internal parameters. A value
+		of `None` corresponds to the optimally performing precision,
+		which is `torch.half` on most systems. A value of `torch.float`
+		may yield higher numerical accuracy, but is generally slower.
+		A value of `torch.half` may not be supported on all systems.
+	"""
+	def __init__(self, n_input_dims, encoding_config, seed=1337, dtype=None):
 		self.n_input_dims = n_input_dims
 		self.encoding_config = encoding_config
+		if dtype is None:
+			self.precision = _C.preferred_precision()
+		else:
+			if dtype == torch.float32:
+				self.precision = _C.Precision.Fp32
+			elif dtype == torch.float16:
+				self.precision = _C.Precision.Fp16
+			else:
+				raise ValueError(f"Encoding only supports fp32 or fp16 precision, but got {dtype}")
 
-		super(Encoding, self).__init__()
+		super(Encoding, self).__init__(seed=seed)
 
 		self.n_output_dims = self.native_tcnn_module.n_output_dims()
 
 	def _native_tcnn_module(self):
-		return _C.Module(self.n_input_dims, self.encoding_config)
+		return _C.Module(self.n_input_dims, self.encoding_config, self.precision)

--- a/include/tiny-cuda-nn/common.h
+++ b/include/tiny-cuda-nn/common.h
@@ -49,6 +49,8 @@ TCNN_NAMESPACE_BEGIN
 
 static constexpr uint32_t MIN_GPU_ARCH = TCNN_MIN_GPU_ARCH;
 
+#define TCNN_HALF_PRECISION (!(TCNN_MIN_GPU_ARCH == 61 || TCNN_MIN_GPU_ARCH <= 52))
+
 // TCNN has the following behavior depending on GPU arch.
 // Refer to the first row of the table at the following URL for information about
 // when to pick fp16 versus fp32 precision for maximum performance.
@@ -62,7 +64,7 @@ static constexpr uint32_t MIN_GPU_ARCH = TCNN_MIN_GPU_ARCH;
 // 53-60, 62 |                      no |                       70 |  __half (no tensor cores)
 //  <=52, 61 |                      no |                       70 |   float (no tensor cores)
 
-using network_precision_t = std::conditional_t<MIN_GPU_ARCH == 61 || MIN_GPU_ARCH <= 52, float, __half>;
+using network_precision_t = std::conditional_t<TCNN_HALF_PRECISION, __half, float>;
 
 // Optionally: set the precision to `float` to disable tensor cores and debug potential
 //             problems with mixed-precision training.

--- a/include/tiny-cuda-nn/cpp_api.h
+++ b/include/tiny-cuda-nn/cpp_api.h
@@ -58,7 +58,7 @@ struct Context {
 
 class Module {
 public:
-	Module(EPrecision output_precision) : m_output_precision{output_precision} {}
+	Module(EPrecision param_precision, EPrecision output_precision) : m_param_precision{param_precision}, m_output_precision{output_precision} {}
 	virtual ~Module() {}
 
 	virtual void inference(cudaStream_t stream, uint32_t n_elements, const float* input, void* output, void* params) = 0;
@@ -68,7 +68,9 @@ public:
 	virtual uint32_t n_input_dims() const = 0;
 
 	virtual size_t n_params() const = 0;
-	virtual EPrecision param_precision() const = 0;
+	EPrecision param_precision() const {
+		return m_param_precision;
+	}
 
 	virtual void initialize_params(size_t seed, float* params_full_precision) = 0;
 
@@ -78,11 +80,14 @@ public:
 	}
 
 private:
+	EPrecision m_param_precision;
 	EPrecision m_output_precision;
 };
 
-Module* create_encoding(uint32_t n_input_dims, const json& encoding);
+Module* create_encoding(uint32_t n_input_dims, const json& encoding, EPrecision requested_precision);
 Module* create_network_with_input_encoding(uint32_t n_input_dims, uint32_t n_output_dims, const json& encoding, const json& network);
 Module* create_network(uint32_t n_input_dims, uint32_t n_output_dims, const json& network);
+
+EPrecision preferred_precision();
 
 }}

--- a/src/encoding.cu
+++ b/src/encoding.cu
@@ -125,6 +125,9 @@ Encoding<T>* create_encoding(uint32_t n_dims_to_encode, const json& encoding, ui
 	return result;
 }
 
-template Encoding<network_precision_t>* create_encoding(uint32_t n_dims_to_encode, const json& encoding, uint32_t alignment);
+#if TCNN_HALF_PRECISION
+template Encoding<__half>* create_encoding(uint32_t n_dims_to_encode, const json& encoding, uint32_t alignment);
+#endif
+template Encoding<float>* create_encoding(uint32_t n_dims_to_encode, const json& encoding, uint32_t alignment);
 
 TCNN_NAMESPACE_END


### PR DESCRIPTION
Sometimes, it can be desired to run __tiny-cuda-nn__-accelerated encodings at fp32 rather than fp16 in a PyTorch context.

This offers better numerical accuracy in rare cases at the cost of speed, while still potentially being faster than native PyTorch implementations.

(Note that __tiny-cuda-nn__'s PyTorch bindings will _not_ support fp32 MLPs (unless that's all the system can do) as those are better handled by PyTorch itself if desired.)