### PR TITLE
Make GPUMatrix slice-able and unify encoding/network API as byproduct

### DIFF
--- a/include/tiny-cuda-nn/common.h
+++ b/include/tiny-cuda-nn/common.h
@@ -162,6 +162,9 @@ private:
 #define STR(x) STRINGIFY(x)
 #define FILE_LINE __FILE__ ":" STR(__LINE__)
 
+#define CHECK_THROW(x) \
+	do { if (!(x)) throw std::runtime_error(std::string(FILE_LINE " check failed " #x)); } while(0)
+
 /// Checks the result of a cuXXXXXX call and throws an error on failure
 #define CU_CHECK_THROW(x)                                                                          \
 	do {                                                                                           \
@@ -169,7 +172,7 @@ private:
 		if (result != CUDA_SUCCESS) {                                                              \
 			const char *msg;                                                                       \
 			cuGetErrorName(result, &msg);                                                          \
-			throw std::runtime_error(std::string(FILE_LINE " " #x " failed with error ") + msg);  \
+			throw std::runtime_error(std::string(FILE_LINE " " #x " failed with error ") + msg);   \
 		}                                                                                          \
 	} while(0)
 
@@ -180,7 +183,7 @@ private:
 		if (result != CUDA_SUCCESS) {                                                              \
 			const char *msg;                                                                       \
 			cuGetErrorName(result, &msg);                                                          \
-			std::cout << FILE_LINE " " #x " failed with error " << msg << std::endl;  \
+			std::cout << FILE_LINE " " #x " failed with error " << msg << std::endl;               \
 		}                                                                                          \
 	} while(0)
 

--- a/include/tiny-cuda-nn/cutlass_matmul.h
+++ b/include/tiny-cuda-nn/cutlass_matmul.h
@@ -411,19 +411,14 @@ void fc_multiply(cudaStream_t stream, const GPUMatrix<TypeA, LayoutA>& A, const 
 		throw std::runtime_error(std::string("Matrix D has incorrect size ") + std::to_string(D.m()) + "," + std::to_string(D.n()) + "!=" + std::to_string(M) + "," + std::to_string(N));
 	}
 
-	const int lda = LayoutA == RM ? A.n() : A.m();
-	const int ldb = LayoutB == RM ? B.n() : B.m();
-	const int ldc = LayoutC == RM ? C.n() : C.m();
-	const int ldd = LayoutD == RM ? D.n() : D.m();
-
 	if (transfer) {
 		using Gemm = OurGemm<ActivationTransferOp<MatmulTypeAccumulator>, config, MatmulTypeCompute, CutlassLayoutA, MatmulTypeCompute, CutlassLayoutB, MatmulTypeAccumulator, CutlassLayoutC>;
 		typename Gemm::Arguments arguments{
 			{M, N, K},
-			{(MatmulTypeCompute*)A.data(), lda},
-			{(MatmulTypeCompute*)B.data(), ldb},
-			{(MatmulTypeAccumulator*)C.data(), ldc},
-			{(MatmulTypeAccumulator*)D.data(), ldd},
+			{(MatmulTypeCompute*)A.data(), A.stride()},
+			{(MatmulTypeCompute*)B.data(), B.stride()},
+			{(MatmulTypeAccumulator*)C.data(), C.stride()},
+			{(MatmulTypeAccumulator*)D.data(), D.stride()},
 			{act},
 			1
 		};
@@ -433,10 +428,10 @@ void fc_multiply(cudaStream_t stream, const GPUMatrix<TypeA, LayoutA>& A, const 
 		using Gemm = OurGemm<ActivationOp<MatmulTypeAccumulator>, config, MatmulTypeCompute, CutlassLayoutA, MatmulTypeCompute, CutlassLayoutB, MatmulTypeAccumulator, CutlassLayoutC>;
 		typename Gemm::Arguments arguments{
 			{M, N, K},
-			{(MatmulTypeCompute*)A.data(), lda},
-			{(MatmulTypeCompute*)B.data(), ldb},
-			{(MatmulTypeAccumulator*)C.data(), ldc},
-			{(MatmulTypeAccumulator*)D.data(), ldd},
+			{(MatmulTypeCompute*)A.data(), A.stride()},
+			{(MatmulTypeCompute*)B.data(), B.stride()},
+			{(MatmulTypeAccumulator*)C.data(), C.stride()},
+			{(MatmulTypeAccumulator*)D.data(), D.stride()},
 			{act, sum_source},
 			1
 		};
@@ -469,7 +464,7 @@ void fc_multiply(cudaStream_t stream, const GPUMatrix<TypeA, LayoutA>& A, const 
 		fc_multiply<config>(stream, A, B_CM, C, D, act, transfer, sum_source);
 	} else {
 		auto B_RM = GPUMatrix<TypeB, RM>{B};
-		// Only column-major output is supported by CUTLASS, then B is row-major.
+		// Only column-major output is supported by CUTLASS when B is row-major.
 		// The following constructors will throw if that assumption isn't met.
 		auto C_CM = GPUMatrix<TypeC, CM>{C};
 		auto D_CM = GPUMatrix<TypeD, CM>{D};
@@ -512,18 +507,13 @@ void fc_multiply_split_k(cudaStream_t stream, const GPUMatrix<TypeA, LayoutA>& A
 		throw std::runtime_error(std::string("Matrix D has incorrect size ") + std::to_string(D.m()) + "," + std::to_string(D.n()) + "!=" + std::to_string(M) + "," + std::to_string(N));
 	}
 
-	const int lda = LayoutA == RM ? A.n() : A.m();
-	const int ldb = LayoutB == RM ? B.n() : B.m();
-	const int ldc = LayoutC == RM ? C.n() : C.m();
-	const int ldd = LayoutD == RM ? D.n() : D.m();
-
 	using Gemm = SplitKGemm<SumOp<MatmulTypeAccumulator>, config, MatmulTypeCompute, CutlassLayoutA, MatmulTypeCompute, CutlassLayoutB, MatmulTypeAccumulator, CutlassLayoutC>;
 	typename Gemm::Arguments arguments{
 		{M, N, K},
-		{(MatmulTypeCompute*)A.data(), lda},
-		{(MatmulTypeCompute*)B.data(), ldb},
-		{(MatmulTypeAccumulator*)C.data(), ldc},
-		{(MatmulTypeAccumulator*)D.data(), ldd},
+		{(MatmulTypeCompute*)A.data(), A.stride()},
+		{(MatmulTypeCompute*)B.data(), B.stride()},
+		{(MatmulTypeAccumulator*)C.data(), C.stride()},
+		{(MatmulTypeAccumulator*)D.data(), D.stride()},
 		{(TypeCompute)1.0f, (TypeCompute)beta},
 		split_k_slices
 	};

--- a/include/tiny-cuda-nn/encodings/frequency.h
+++ b/include/tiny-cuda-nn/encodings/frequency.h
@@ -125,67 +125,76 @@ public:
 		m_n_padded_output_dims = m_n_output_dims = m_n_dims_to_encode * m_n_frequencies * 2;
 	}
 
-	void encode(
+	std::unique_ptr<Context> forward(
 		cudaStream_t stream,
-		const uint32_t num_elements,
-		PitchedPtr<const float> inputs,
-		PitchedPtr<T> outputs,
-		float* dy_dx = nullptr,
-		bool is_inference = false
-	) const override {
-		if (m_n_padded_output_dims == 0) {
-			return;
+		const GPUMatrixDynamic<float>& input,
+		GPUMatrixDynamic<T>* output = nullptr,
+		bool use_inference_params = false,
+		bool prepare_input_gradients = false
+	) override {
+		auto forward = std::make_unique<ForwardContext>();
+
+		if (!output || m_n_padded_output_dims == 0) {
+			return forward;
+		}
+
+		if (prepare_input_gradients) {
+			forward->dy_dx = GPUMatrix<float>{m_n_dims_to_encode * m_n_frequencies * 2, input.n(), stream};
 		}
 
 		linear_kernel(frequency_encoding<T>, 0, stream,
-			num_elements * num_encoded_dims(),
+			input.n() * padded_output_width(),
 			m_n_frequencies,
 			m_n_dims_to_encode,
 			m_n_to_pad,
-			inputs,
-			outputs,
-			dy_dx
+			input.pitched_ptr(),
+			output->pitched_ptr(),
+			forward->dy_dx.data()
 		);
+
+		return forward;
 	}
 
 	void backward(
 		cudaStream_t stream,
-		const uint32_t num_elements,
-		PitchedPtr<const T> dL_dy, // Same shape as outputs
-		const float* dy_dx, // encoded output dims x num_elements
-		PitchedPtr<float> dL_dx, // Same shape as inputs
-		PitchedPtr<const float> inputs,
-		EGradientMode param_gradients_mode
+		const Context& ctx,
+		const GPUMatrixDynamic<float>& input,
+		const GPUMatrixDynamic<T>& output,
+		const GPUMatrixDynamic<T>& dL_doutput,
+		GPUMatrixDynamic<float>* dL_dinput = nullptr,
+		bool use_inference_params = false,
+		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override {
-		if (m_n_padded_output_dims == 0) {
+		if (!dL_dinput || m_n_padded_output_dims == 0) {
 			return;
 		}
 
-		// Can't compute input gradients if insufficient info is available
-		if (!dy_dx || !dL_dx) {
-			return;
-		}
+		const auto& forward = dynamic_cast<const ForwardContext&>(ctx);
 
 		linear_kernel(frequency_encoding_backward<T>, 0, stream,
-			num_elements * m_n_dims_to_encode,
+			input.n() * m_n_dims_to_encode,
 			m_n_dims_to_encode,
 			m_n_frequencies,
-			dL_dy,
-			dy_dx,
-			dL_dx
+			dL_doutput.pitched_ptr(),
+			forward.dy_dx.data(),
+			dL_dinput->pitched_ptr()
 		);
 	}
 
-	uint32_t num_dims_to_encode() const override {
+	uint32_t input_width() const override {
 		return m_n_dims_to_encode;
 	}
 
-	uint32_t num_encoded_dims() const override {
+	uint32_t padded_output_width() const override {
 		return m_n_padded_output_dims;
 	}
 
-	uint32_t num_forward_gradient_dims() const override {
-		return m_n_dims_to_encode * m_n_frequencies * 2;
+	uint32_t output_width() const override {
+		return m_n_padded_output_dims;
+	}
+
+	uint32_t required_input_alignment() const override {
+		return 1;
 	}
 
 	void set_alignment(uint32_t alignment) override {
@@ -198,6 +207,10 @@ public:
 		return 1;
 	}
 
+	MatrixLayout preferred_output_layout() const override {
+		return AoS;
+	}
+
 	json hyperparams() const override {
 		return {
 			{"otype", "Frequency"},
@@ -206,6 +219,10 @@ public:
 	}
 
 private:
+	struct ForwardContext : public Context {
+		GPUMatrix<float> dy_dx;
+	};
+
 	uint32_t m_n_frequencies;
 	uint32_t m_n_dims_to_encode;
 

--- a/include/tiny-cuda-nn/encodings/identity.h
+++ b/include/tiny-cuda-nn/encodings/identity.h
@@ -53,8 +53,7 @@ __global__ void identity(
 	const float offset,
 	MatrixLayout output_layout,
 	PitchedPtr<const float> data_in,
-	PitchedPtr<T> data_out,
-	float* __restrict__ dy_dx)
+	PitchedPtr<T> data_out)
 {
 	const uint32_t encoded_index = threadIdx.x + blockIdx.x * blockDim.x;
 	if (encoded_index >= num_outputs) return;
@@ -69,9 +68,6 @@ __global__ void identity(
 		*out = 1;
 	} else {
 		*out = data_in(i)[j] * scale + offset;
-		if (dy_dx != nullptr) {
-			dy_dx[i * num_to_encode + j] = scale;
-		}
 	}
 }
 
@@ -83,7 +79,6 @@ __global__ void identity_backward(
 	const float scale,
 	MatrixLayout output_layout,
 	PitchedPtr<const T> dL_dy,
-	const float* dy_dx,
 	PitchedPtr<float> dL_dx)
 {
 	const uint32_t output_index = threadIdx.x + blockIdx.x * blockDim.x;
@@ -106,72 +101,73 @@ public:
 		m_n_padded_output_dims = m_n_output_dims = m_n_dims_to_encode;
 	}
 
-	void encode(
+	std::unique_ptr<Context> forward(
 		cudaStream_t stream,
-		const uint32_t num_elements,
-		PitchedPtr<const float> inputs,
-		PitchedPtr<T> outputs,
-		float* dy_dx = nullptr,
-		bool is_inference = false
-	) const override {
-		if (m_n_padded_output_dims == 0) {
-			return;
+		const GPUMatrixDynamic<float>& input,
+		GPUMatrixDynamic<T>* output = nullptr,
+		bool use_inference_params = false,
+		bool prepare_input_gradients = false
+	) override {
+		if (!output || m_n_padded_output_dims == 0) {
+			return std::make_unique<Context>();
 		}
 
 		linear_kernel(identity<T>, 0, stream,
-			num_elements * num_encoded_dims(),
-			num_elements,
+			input.n() * padded_output_width(),
+			input.n(),
 			m_n_dims_to_encode,
 			m_n_to_pad,
 			m_scale,
 			m_offset,
-			m_output_layout,
-			inputs,
-			outputs,
-			dy_dx
+			output->layout(),
+			input.pitched_ptr(),
+			output->pitched_ptr()
 		);
+
+		return std::make_unique<Context>();
 	}
 
 	void backward(
 		cudaStream_t stream,
-		const uint32_t num_elements,
-		PitchedPtr<const T> dL_dy, // Same shape as outputs
-		const float* dy_dx, // encoded output dims x num_elements
-		PitchedPtr<float> dL_dx, // Same shape as inputs
-		PitchedPtr<const float> inputs,
-		EGradientMode param_gradients_mode
+		const Context& ctx,
+		const GPUMatrixDynamic<float>& input,
+		const GPUMatrixDynamic<T>& output,
+		const GPUMatrixDynamic<T>& dL_doutput,
+		GPUMatrixDynamic<float>* dL_dinput = nullptr,
+		bool use_inference_params = false,
+		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override {
-		if (m_n_padded_output_dims == 0) {
+		if (!dL_dinput || m_n_padded_output_dims == 0) {
 			return;
 		}
 
-		// Can't compute input gradients if insufficient info is available
-		if (!dy_dx || !dL_dx) {
-			return;
-		}
+		CHECK_THROW(dL_doutput.layout() == output.layout());
 
 		linear_kernel(identity_backward<T>, 0, stream,
-			num_elements * m_n_dims_to_encode,
-			num_elements,
+			input.n() * m_n_dims_to_encode,
+			input.n(),
 			m_n_dims_to_encode,
 			m_scale,
-			m_output_layout,
-			dL_dy,
-			dy_dx,
-			dL_dx
+			output.layout(),
+			dL_doutput.pitched_ptr(),
+			dL_dinput->pitched_ptr()
 		);
 	}
 
-	uint32_t num_dims_to_encode() const override {
+	uint32_t input_width() const override {
 		return m_n_dims_to_encode;
 	}
 
-	uint32_t num_encoded_dims() const override {
+	uint32_t padded_output_width() const override {
 		return m_n_padded_output_dims;
 	}
 
-	uint32_t num_forward_gradient_dims() const override {
-		return m_n_dims_to_encode;
+	uint32_t output_width() const override {
+		return m_n_padded_output_dims;
+	}
+
+	uint32_t required_input_alignment() const override {
+		return 1;
 	}
 
 	void set_alignment(uint32_t alignment) override {
@@ -184,16 +180,8 @@ public:
 		return 1;
 	}
 
-	bool supports_output_layout(MatrixLayout layout) const override {
-		return true;
-	}
-
-	void set_output_layout(MatrixLayout layout) override {
-		m_output_layout = layout;
-	}
-
-	MatrixLayout output_layout() const override {
-		return m_output_layout;
+	MatrixLayout preferred_output_layout() const override {
+		return SoA;
 	}
 
 	json hyperparams() const override {
@@ -214,8 +202,6 @@ private:
 	uint32_t m_n_output_dims;
 	uint32_t m_n_padded_output_dims;
 	uint32_t m_n_to_pad = 0;
-
-	MatrixLayout m_output_layout = AoS;
 };
 
 TCNN_NAMESPACE_END

--- a/include/tiny-cuda-nn/encodings/spherical_harmonics.h
+++ b/include/tiny-cuda-nn/encodings/spherical_harmonics.h
@@ -414,67 +414,70 @@ public:
 		}
 	}
 
-	void encode(
+	std::unique_ptr<Context> forward(
 		cudaStream_t stream,
-		const uint32_t num_elements,
-		PitchedPtr<const float> inputs,
-		PitchedPtr<T> outputs,
-		float* dy_dx = nullptr,
-		bool is_inference = false
-	) const override {
-		if (m_n_padded_output_dims == 0) {
-			return;
+		const GPUMatrixDynamic<float>& input,
+		GPUMatrixDynamic<T>* output = nullptr,
+		bool use_inference_params = false,
+		bool prepare_input_gradients = false
+	) override {
+		if (!output || m_n_padded_output_dims == 0) {
+			return std::make_unique<Context>();
 		}
 
 		linear_kernel(kernel_sh<T>, 0, stream,
-			num_elements,
+			input.n(),
 			m_degree,
 			m_n_to_pad,
-			m_output_layout,
-			inputs,
-			outputs
+			output->layout(),
+			input.pitched_ptr(),
+			output->pitched_ptr()
 		);
+
+		return std::make_unique<Context>();
 	}
 
 	void backward(
 		cudaStream_t stream,
-		const uint32_t num_elements,
-		PitchedPtr<const T> dL_dy, // Same shape as outputs
-		const float* dy_dx, // encoded output dims x num_elements
-		PitchedPtr<float> dL_dx, // Same shape as inputs
-		PitchedPtr<const float> inputs,
-		EGradientMode param_gradients_mode
+		const Context& ctx,
+		const GPUMatrixDynamic<float>& input,
+		const GPUMatrixDynamic<T>& output,
+		const GPUMatrixDynamic<T>& dL_doutput,
+		GPUMatrixDynamic<float>* dL_dinput = nullptr,
+		bool use_inference_params = false,
+		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override {
-		if (m_n_padded_output_dims == 0) {
+		if (!dL_dinput || m_n_padded_output_dims == 0) {
 			return;
 		}
 
-		// Can't compute input gradients if insufficient info is available
-		if (!dL_dx) {
-			return;
-		}
+		CHECK_THROW(dL_doutput.layout() == output.layout());
 
 		linear_kernel(kernel_sh_backward<T>, 0, stream,
-			num_elements,
+			input.n(),
 			m_degree,
 			m_n_to_pad,
-			m_output_layout,
-			dL_dy,
-			inputs,
-			dL_dx
+			output.layout(),
+			dL_doutput.pitched_ptr(),
+			input.pitched_ptr(),
+			dL_dinput->pitched_ptr()
 		);
 	}
 
-	uint32_t num_dims_to_encode() const override {
+	uint32_t input_width() const override {
 		return m_n_dims_to_encode;
 	}
 
-	uint32_t num_encoded_dims() const override {
+	uint32_t padded_output_width() const override {
 		return m_n_padded_output_dims;
 	}
 
-	uint32_t num_forward_gradient_dims() const override {
-		return 0;
+	uint32_t output_width() const override {
+		return m_n_padded_output_dims;
+	}
+
+	uint32_t required_input_alignment() const override {
+		return 1;
 	}
 
 	void set_alignment(uint32_t alignment) override {
@@ -487,16 +490,8 @@ public:
 		return 1;
 	}
 
-	bool supports_output_layout(MatrixLayout layout) const override {
-		return true;
-	}
-
-	void set_output_layout(MatrixLayout layout) override {
-		m_output_layout = layout;
-	}
-
-	MatrixLayout output_layout() const override {
-		return m_output_layout;
+	MatrixLayout preferred_output_layout() const override {
+		return SoA;
 	}
 
 	json hyperparams() const override {
@@ -515,8 +510,6 @@ private:
 	uint32_t m_n_output_dims;
 	uint32_t m_n_padded_output_dims;
 	uint32_t m_n_to_pad = 0;
-
-	MatrixLayout m_output_layout = AoS;
 };
 
 TCNN_NAMESPACE_END

--- a/include/tiny-cuda-nn/network.h
+++ b/include/tiny-cuda-nn/network.h
@@ -52,11 +52,6 @@ class Network : public DifferentiableObject<T, PARAMS_T, PARAMS_T> {
 public:
 	virtual ~Network() { }
 
-	virtual void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<PARAMS_T>& output, bool use_inference_matrices = true) = 0;
-	void inference_mixed_precision(const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<PARAMS_T>& output, bool use_inference_matrices = true) {
-		inference_mixed_precision(nullptr, input, output, use_inference_matrices);
-	}
-
 	void visualize_activation(cudaStream_t stream, uint32_t layer, uint32_t dimension, const GPUMatrix<T>& input, GPUMatrix<float>& output) {
 		layer = std::min(layer, num_forward_activations()-1);
 		dimension = std::min(dimension, width(layer)-1);

--- a/include/tiny-cuda-nn/networks/cutlass_mlp.h
+++ b/include/tiny-cuda-nn/networks/cutlass_mlp.h
@@ -53,10 +53,9 @@ public:
 	);
 	~CutlassMLP() override;
 
-	void inference(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<float>& output) override;
-	void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_matrices = true) override;
+	void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params = true) override;
 
-	std::unique_ptr<Context> forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_matrices = false, bool prepare_input_gradients = false) override;
+	std::unique_ptr<Context> forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_params = false, bool prepare_input_gradients = false) override;
 
 	void backward(
 		cudaStream_t stream,
@@ -65,7 +64,7 @@ public:
 		const GPUMatrixDynamic<T>& output,
 		const GPUMatrixDynamic<T>& dL_doutput,
 		GPUMatrixDynamic<T>* dL_dinput = nullptr,
-		bool use_inference_matrices = false,
+		bool use_inference_params = false,
 		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override;
 
@@ -101,6 +100,10 @@ public:
 
 	size_t n_params() const override {
 		return m_total_n_params;
+	}
+
+	uint32_t input_width() const override {
+		return m_input_width;
 	}
 
 	uint32_t padded_output_width() const override {

--- a/include/tiny-cuda-nn/networks/cutlass_resnet.h
+++ b/include/tiny-cuda-nn/networks/cutlass_resnet.h
@@ -50,10 +50,9 @@ public:
 	CutlassResNet(uint32_t input_width, uint32_t network_width, uint32_t output_width, uint32_t n_blocks, uint32_t n_matrices_per_block, Activation output_activation);
 	~CutlassResNet() override;
 
-	void inference(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<float>& output) override;
-	void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_matrices = true) override;
+	void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params = true) override;
 
-	std::unique_ptr<Context> forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_matrices = false, bool prepare_input_gradients = false) override;
+	std::unique_ptr<Context> forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_params = false, bool prepare_input_gradients = false) override;
 
 	void backward(
 		cudaStream_t stream,
@@ -62,7 +61,7 @@ public:
 		const GPUMatrixDynamic<T>& output,
 		const GPUMatrixDynamic<T>& dL_doutput,
 		GPUMatrixDynamic<T>* dL_dinput = nullptr,
-		bool use_inference_matrices = false,
+		bool use_inference_params = false,
 		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override;
 
@@ -98,6 +97,10 @@ public:
 
 	size_t n_params() const override {
 		return m_total_n_params;
+	}
+
+	uint32_t input_width() const override {
+		return m_input_width;
 	}
 
 	uint32_t padded_output_width() const override {

--- a/include/tiny-cuda-nn/networks/fully_fused_mlp.h
+++ b/include/tiny-cuda-nn/networks/fully_fused_mlp.h
@@ -46,10 +46,9 @@ public:
 	FullyFusedMLP(uint32_t input_width, uint32_t output_width, uint32_t n_hidden_layers, bool use_feedback_alignment, Activation activation, Activation output_activation);
 	~FullyFusedMLP() override;
 
-	void inference(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<float>& output) override;
-	void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_matrices = true) override;
+	void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params = true) override;
 
-	std::unique_ptr<Context> forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_matrices = false, bool prepare_input_gradients = false) override;
+	std::unique_ptr<Context> forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_params = false, bool prepare_input_gradients = false) override;
 
 	void backward(
 		cudaStream_t stream,
@@ -58,7 +57,7 @@ public:
 		const GPUMatrixDynamic<T>& output,
 		const GPUMatrixDynamic<T>& dL_doutput,
 		GPUMatrixDynamic<T>* dL_dinput = nullptr,
-		bool use_inference_matrices = false,
+		bool use_inference_params = false,
 		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override;
 
@@ -109,6 +108,10 @@ public:
 
 	size_t n_params() const override {
 		return m_total_n_params;
+	}
+
+	uint32_t input_width() const override {
+		return m_input_width;
 	}
 
 	uint32_t padded_output_width() const override {

--- a/include/tiny-cuda-nn/object.h
+++ b/include/tiny-cuda-nn/object.h
@@ -79,6 +79,9 @@ void one_hot_batched(cudaStream_t stream, const uint32_t num_elements, const uin
 template <typename T>
 void mult(cudaStream_t stream, const uint32_t num_elements, T* inout, float factor);
 
+template <typename T>
+void trim_and_cast_from(cudaStream_t stream, const MatrixLayout layout, const uint32_t num_elements, const uint32_t input_width, const uint32_t output_width, const T* in, float* out);
+
 enum class EGradientMode {
 	Ignore,
 	Overwrite,
@@ -90,7 +93,23 @@ class DifferentiableObject : public ParametricObject<PARAMS_T> {
 public:
 	virtual ~DifferentiableObject() { }
 
-	virtual void inference(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<float>& output) = 0;
+	virtual void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<COMPUTE_T>& output, bool use_inference_params = true) = 0;
+	void inference_mixed_precision(const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<COMPUTE_T>& output, bool use_inference_params = true) {
+		inference_mixed_precision(nullptr, input, output, use_inference_params);
+	}
+
+	void inference(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<float>& output) {
+		check_inference_args(input, output);
+
+		GPUMatrixDynamic<COMPUTE_T> inference_output_tmp{padded_output_width(), output.n(), stream, output.layout()};
+		inference_mixed_precision(stream, input, inference_output_tmp);
+
+		// TODO: handle the case where T == float and padded_output_width() == output_width()
+
+		const uint32_t n_elements = (uint32_t)output.n_elements();
+		trim_and_cast_from(stream, output.layout(), n_elements, padded_output_width(), output_width(), inference_output_tmp.data(), output.data());
+	}
+
 	void inference(const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<float>& output) {
 		inference(nullptr, input, output);
 	}
@@ -99,16 +118,16 @@ public:
 		cudaStream_t stream,
 		const GPUMatrixDynamic<T>& input,
 		GPUMatrixDynamic<COMPUTE_T>* output = nullptr,
-		bool use_inference_matrices = false,
+		bool use_inference_params = false,
 		bool prepare_input_gradients = false
 	) = 0;
 	std::unique_ptr<Context> forward(
 		const GPUMatrixDynamic<T>& input,
 		GPUMatrixDynamic<COMPUTE_T>* output = nullptr,
-		bool use_inference_matrices = false,
+		bool use_inference_params = false,
 		bool prepare_input_gradients = false
 	) {
-		return forward(nullptr, input, output, use_inference_matrices, prepare_input_gradients);
+		return forward(nullptr, input, output, use_inference_params, prepare_input_gradients);
 	}
 
 	virtual void backward(
@@ -118,7 +137,7 @@ public:
 		const GPUMatrixDynamic<COMPUTE_T>& output,
 		const GPUMatrixDynamic<COMPUTE_T>& dL_doutput,
 		GPUMatrixDynamic<T>* dL_dinput = nullptr,
-		bool use_inference_matrices = false,
+		bool use_inference_params = false,
 		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) = 0;
 	void backward(
@@ -127,10 +146,10 @@ public:
 		const GPUMatrixDynamic<COMPUTE_T>& output,
 		const GPUMatrixDynamic<COMPUTE_T>& dL_doutput,
 		GPUMatrixDynamic<T>* dL_dinput = nullptr,
-		bool use_inference_matrices = false,
+		bool use_inference_params = false,
 		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) {
-		backward(nullptr, input, output, dL_doutput, dL_dinput, use_inference_matrices, param_gradients_mode);
+		backward(nullptr, input, output, dL_doutput, dL_dinput, use_inference_params, param_gradients_mode);
 	}
 
 	void input_gradient(
@@ -159,10 +178,48 @@ public:
 		mult(stream, d_dinput.n_elements(), d_dinput.data(), 1.0f / backprop_scale);
 	}
 
+	virtual uint32_t input_width() const = 0;
+
 	virtual uint32_t padded_output_width() const = 0;
 	virtual uint32_t output_width() const = 0;
 
 	virtual uint32_t required_input_alignment() const = 0;
+
+	void check_inference_args(const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<float>& output) {
+		CHECK_THROW(input.m() == input_width());
+		CHECK_THROW(output.m() == output_width());
+		CHECK_THROW(input.n() == output.n());
+	}
+
+	void check_inference_mixed_precision_args(const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<COMPUTE_T>& output) {
+		CHECK_THROW(input.m() == input_width());
+		CHECK_THROW(output.m() == padded_output_width());
+		CHECK_THROW(input.n() == output.n());
+	}
+
+	void check_forward_args(const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<COMPUTE_T>* output) {
+		CHECK_THROW(input.m() == input_width());
+		CHECK_THROW(!output || output->m() == padded_output_width());
+		CHECK_THROW(!output || input.n() == output->n());
+	}
+
+	void check_backward_args(
+		const GPUMatrixDynamic<T>& input,
+		const GPUMatrixDynamic<COMPUTE_T>& output,
+		const GPUMatrixDynamic<COMPUTE_T>& dL_doutput,
+		GPUMatrixDynamic<T>* dL_dinput
+	) {
+		// Width
+		CHECK_THROW(input.m() == input_width());
+		CHECK_THROW(output.m() == padded_output_width());
+		CHECK_THROW(dL_doutput.m() == padded_output_width());
+		CHECK_THROW(!dL_dinput || dL_dinput->m() == input_width());
+
+		// Equal batch size
+		CHECK_THROW(input.n() == output.n());
+		CHECK_THROW(input.n() == dL_doutput.n());
+		CHECK_THROW(!dL_dinput || input.n() == dL_dinput->n());
+	}
 };
 
 TCNN_NAMESPACE_END

--- a/src/cutlass_resnet.cu
+++ b/src/cutlass_resnet.cu
@@ -101,33 +101,8 @@ CutlassResNet<T, input_activation>::~CutlassResNet() {
 }
 
 template <typename T, Activation input_activation>
-void CutlassResNet<T, input_activation>::inference(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<float>& output) {
-	GPUMatrixDynamic<T> inference_output_tmp{m_padded_output_width, output.n(), stream, output.layout()};
-	inference_mixed_precision(stream, input, inference_output_tmp);
-
-	const uint32_t n_elements = (uint32_t)output.n_elements();
-	if (output.layout() == RM) {
-		// If the layout is row major, trimming away excess dimensions amounts to simply discarding the tail of the buffer.
-		cast_from<T><<<n_blocks_linear(n_elements), n_threads_linear, 0, stream>>>(n_elements, inference_output_tmp.data(), output.data());
-	} else {
-		trim_and_cast<T><<<n_blocks_linear(n_elements), n_threads_linear, 0, stream>>>(n_elements, m_padded_output_width, m_output_width, inference_output_tmp.data(), output.data());
-	}
-}
-
-template <typename T, Activation input_activation>
-void CutlassResNet<T, input_activation>::inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_matrices) {
-	// Various error checks
-	if (input.m() != m_input_width) {
-		throw std::runtime_error(std::string("Input has incorrect width: ") + std::to_string(input.m()) + "!=" + std::to_string(m_input_width));
-	}
-
-	if (output.m() != m_padded_output_width) {
-		throw std::runtime_error(std::string("Output has incorrect width: ") + std::to_string(output.m()) + "!=" + std::to_string(m_output_width));
-	}
-
-	if (input.n() != output.n()) {
-		throw std::runtime_error(std::string("Input and output don't have matching batch size: ") + std::to_string(input.n()) + "!=" + std::to_string(output.n()));
-	}
+void CutlassResNet<T, input_activation>::inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params) {
+	check_inference_mixed_precision_args(input, output);
 
 	uint32_t batch_size = input.n();
 
@@ -140,14 +115,14 @@ void CutlassResNet<T, input_activation>::inference_mixed_precision(cudaStream_t 
 	// Run the actual network
 	{
 		// Input
-		fc_multiply<FullLayer>(stream, input_weight_matrix(use_inference_matrices), input, inference_linear_tmp, inference_linear_tmp, input_activation);
+		fc_multiply<FullLayer>(stream, input_weight_matrix(use_inference_params), input, inference_linear_tmp, inference_linear_tmp, input_activation);
 
 		// Res blocks
 		for (uint32_t i = 0; i < m_n_blocks; ++i) {
-			fc_multiply<FullLayerPreReLU>(stream, weight_matrix_at(use_inference_matrices, i, 0), inference_linear_tmp, inference_residual_tmp[0]);
+			fc_multiply<FullLayerPreReLU>(stream, weight_matrix_at(use_inference_params, i, 0), inference_linear_tmp, inference_residual_tmp[0]);
 
 			for (uint32_t matrix_idx = 1; matrix_idx < m_n_matrices_per_block - 1; ++matrix_idx) {
-				fc_multiply<FullLayerPreReLU>(stream, weight_matrix_at(use_inference_matrices, i, matrix_idx), inference_residual_tmp[(matrix_idx+1) % 2], inference_residual_tmp[matrix_idx % 2]);
+				fc_multiply<FullLayerPreReLU>(stream, weight_matrix_at(use_inference_params, i, matrix_idx), inference_residual_tmp[(matrix_idx+1) % 2], inference_residual_tmp[matrix_idx % 2]);
 			}
 
 			// In case there's just 1 matrix per block, the remaining addition must be done manually
@@ -158,7 +133,7 @@ void CutlassResNet<T, input_activation>::inference_mixed_precision(cudaStream_t 
 				uint32_t matrix_idx = m_n_matrices_per_block - 1;
 				fc_multiply<FullLayerPreReLU>(
 					stream,
-					weight_matrix_at(use_inference_matrices, i, matrix_idx),
+					weight_matrix_at(use_inference_params, i, matrix_idx),
 					inference_residual_tmp[(matrix_idx+1) % 2],
 					inference_linear_tmp,
 					inference_linear_tmp,
@@ -170,24 +145,13 @@ void CutlassResNet<T, input_activation>::inference_mixed_precision(cudaStream_t 
 		}
 
 		// Output
-		fc_multiply<LastLayer>(stream, output_weight_matrix(use_inference_matrices), inference_linear_tmp, output, m_output_activation);
+		fc_multiply<LastLayer>(stream, output_weight_matrix(use_inference_params), inference_linear_tmp, output, m_output_activation);
 	}
 }
 
 template <typename T, Activation input_activation>
-std::unique_ptr<Context> CutlassResNet<T, input_activation>::forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output, bool use_inference_matrices, bool prepare_input_gradients) {
-	// Various error checks
-	if (input.m() != m_input_width) {
-		throw std::runtime_error(std::string("Input has incorrect width: ") + std::to_string(input.m()) + "!=" + std::to_string(m_input_width));
-	}
-
-	if (output && output->m() != m_padded_output_width) {
-		throw std::runtime_error(std::string("Output has incorrect width (must be padded): ") + std::to_string(output->m()) + "!=" + std::to_string(m_padded_output_width));
-	}
-
-	if (output && input.n() != output->n()) {
-		throw std::runtime_error(std::string("Input and output don't have matching batch size: ") + std::to_string(input.n()) + "!=" + std::to_string(output->n()));
-	}
+std::unique_ptr<Context> CutlassResNet<T, input_activation>::forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output, bool use_inference_params, bool prepare_input_gradients) {
+	check_forward_args(input, output);
 
 	// Make sure our temporary buffers have the correct size for the given batch size
 	uint32_t batch_size = input.n();
@@ -198,7 +162,7 @@ std::unique_ptr<Context> CutlassResNet<T, input_activation>::forward(cudaStream_
 	// Run the actual network
 	{
 		auto& input_target = input_activation_value == Activation::None ? forward->hidden.front() : forward->input;
-		fc_multiply<FullLayer>(stream, input_weight_matrix(use_inference_matrices), input, input_target);
+		fc_multiply<FullLayer>(stream, input_weight_matrix(use_inference_params), input, input_target);
 		activation_gpu(stream, input_activation_value, input_target, forward->hidden.front());
 
 		// Res blocks
@@ -206,21 +170,21 @@ std::unique_ptr<Context> CutlassResNet<T, input_activation>::forward(cudaStream_
 			uint32_t idx = i * m_n_matrices_per_block + 1;
 
 			if (m_n_matrices_per_block == 1) {
-				fc_multiply<FullLayerPreReLU>(stream, weight_matrix_at(use_inference_matrices, i, 0), forward->hidden.at(idx-1), forward->hidden.at(idx));
+				fc_multiply<FullLayerPreReLU>(stream, weight_matrix_at(use_inference_params, i, 0), forward->hidden.at(idx-1), forward->hidden.at(idx));
 				add<T><<<n_blocks_linear(n_elements), n_threads_linear, 0, stream>>>(n_elements, forward->hidden.at(idx-1).data(), forward->hidden.at(idx).data());
 			} else {
-				fc_multiply<FullLayerPreReLU>(stream, weight_matrix_at(use_inference_matrices, i, 0), forward->hidden.at(idx-1), forward->hidden.at(idx), Activation::ReLU);
+				fc_multiply<FullLayerPreReLU>(stream, weight_matrix_at(use_inference_params, i, 0), forward->hidden.at(idx-1), forward->hidden.at(idx), Activation::ReLU);
 
 				for (uint32_t matrix_idx = 1; matrix_idx < m_n_matrices_per_block - 1; ++matrix_idx) {
 					uint32_t fwd_idx = idx + matrix_idx;
-					fc_multiply<FullLayer>(stream, weight_matrix_at(use_inference_matrices, i, matrix_idx), forward->hidden.at(fwd_idx-1), forward->hidden.at(fwd_idx), Activation::ReLU);
+					fc_multiply<FullLayer>(stream, weight_matrix_at(use_inference_params, i, matrix_idx), forward->hidden.at(fwd_idx-1), forward->hidden.at(fwd_idx), Activation::ReLU);
 				}
 
 				uint32_t matrix_idx = m_n_matrices_per_block - 1;
 				uint32_t fwd_idx = idx + matrix_idx;
 				fc_multiply<FullLayer>(
 					stream,
-					weight_matrix_at(use_inference_matrices, i, matrix_idx),
+					weight_matrix_at(use_inference_params, i, matrix_idx),
 					forward->hidden.at(fwd_idx-1),
 					forward->hidden.at(idx-1),
 					forward->hidden.at(fwd_idx),
@@ -237,7 +201,7 @@ std::unique_ptr<Context> CutlassResNet<T, input_activation>::forward(cudaStream_
 		}
 
 		if (output) {
-			fc_multiply<LastLayer>(stream, output_weight_matrix(use_inference_matrices), forward->hidden.back(), *output, m_output_activation);
+			fc_multiply<LastLayer>(stream, output_weight_matrix(use_inference_params), forward->hidden.back(), *output, m_output_activation);
 		}
 	}
 
@@ -252,12 +216,10 @@ void CutlassResNet<T, input_activation>::backward(
 	const GPUMatrixDynamic<T>& output,
 	const GPUMatrixDynamic<T>& dL_doutput,
 	GPUMatrixDynamic<T>* dL_dinput,
-	bool use_inference_matrices,
+	bool use_inference_params,
 	EGradientMode param_gradients_mode
 ) {
-	if (dL_doutput.m() != m_padded_output_width) {
-		throw std::runtime_error(std::string("Output gradients have incorrect width (must be padded): ") + std::to_string(dL_doutput.m()) + "!=" + std::to_string(m_padded_output_width));
-	}
+	check_backward_args(input, output, dL_doutput, dL_dinput);
 
 	// Make sure our temporary buffers have the correct size for the given batch size
 	uint32_t batch_size = dL_doutput.n();
@@ -298,7 +260,7 @@ void CutlassResNet<T, input_activation>::backward(
 			cudaEventRecord(m_training_splitk_events.back(), m_training_splitk_streams.back());
 		}
 
-		fc_multiply<FullLayer>(stream, output_weight_matrix(use_inference_matrices).transposed(), tmp_dL_doutput, backward_tmp.back());
+		fc_multiply<FullLayer>(stream, output_weight_matrix(use_inference_params).transposed(), tmp_dL_doutput, backward_tmp.back());
 
 		// Res blocks
 		for (uint32_t i = 0; i < m_n_blocks; ++i) {
@@ -316,7 +278,7 @@ void CutlassResNet<T, input_activation>::backward(
 					cudaEventRecord(m_training_splitk_events.at(fwd_idx), m_training_splitk_streams.at(fwd_idx));
 				}
 
-				fc_multiply<FullLayer>(stream, weight_matrix_at(use_inference_matrices, block_idx, matrix_idx).transposed(), backward_tmp.at(fwd_idx), forward.hidden.at(fwd_idx-1), backward_tmp.at(fwd_idx-1), Activation::ReLU, true);
+				fc_multiply<FullLayer>(stream, weight_matrix_at(use_inference_params, block_idx, matrix_idx).transposed(), backward_tmp.at(fwd_idx), forward.hidden.at(fwd_idx-1), backward_tmp.at(fwd_idx-1), Activation::ReLU, true);
 			}
 
 			add<T><<<n_blocks_linear(n_elements), n_threads_linear, 0, stream>>>(n_elements, backward_tmp.at(idx+m_n_matrices_per_block-1).data(), backward_tmp.at(idx-1).data());
@@ -334,7 +296,7 @@ void CutlassResNet<T, input_activation>::backward(
 		// If requested, compute sensitivity of loss w.r.t. inputs
 		if (dL_dinput) {
 			// TODO: optimization opportunity to only compute sensitivity w.r.t selected SUBSET of inputs. Useful for NFs, where conditional dims stay the same.
-			fc_multiply<FullLayer>(stream, input_weight_matrix(use_inference_matrices).transposed(), backward_tmp.front(), *dL_dinput);
+			fc_multiply<FullLayer>(stream, input_weight_matrix(use_inference_params).transposed(), backward_tmp.front(), *dL_dinput);
 		}
 	}
 

--- a/src/object.cu
+++ b/src/object.cu
@@ -60,4 +60,16 @@ void mult(cudaStream_t stream, const uint32_t num_elements, T* inout, float fact
 template void mult(cudaStream_t stream, const uint32_t num_elements, float* inout, float factor);
 template void mult(cudaStream_t stream, const uint32_t num_elements, __half* inout, float factor);
 
+template <typename T>
+void trim_and_cast_from(cudaStream_t stream, const MatrixLayout layout, const uint32_t num_elements, const uint32_t input_width, const uint32_t output_width, const T* in, float* out) {
+	if (layout == RM) {
+		linear_kernel(cast_from<T>, 0, stream, num_elements, in, out);
+	} else {
+		linear_kernel(trim_and_cast<T>, 0, stream, num_elements, input_width, output_width, in, out);
+	}
+}
+
+template void trim_and_cast_from(cudaStream_t stream, const MatrixLayout layout, const uint32_t num_elements, const uint32_t input_width, const uint32_t output_width, const float* in, float* out);
+template void trim_and_cast_from(cudaStream_t stream, const MatrixLayout layout, const uint32_t num_elements, const uint32_t input_width, const uint32_t output_width, const __half* in, float* out);
+
 TCNN_NAMESPACE_END


### PR DESCRIPTION
`Encoding` and `Network` so far had different APIs due to legacy implementation differences.

These have now been largely eliminated: both components can handle AoS + SoA operation, slicing, and input + parameter gradient computation. Hence the unification of their API.

This is a breaking change for direct consumers of the `Encoding` class, which is hopefully the minority of users. PyTorch bindings, `Network`, and `NetworkWithInputEncoding` are unaffected.