### PR TITLE
Misc improvements

### DIFF
--- a/include/tiny-cuda-nn/gpu_matrix.h
+++ b/include/tiny-cuda-nn/gpu_matrix.h
@@ -184,13 +184,13 @@ public:
 	}
 
 	GPUMatrixDynamic<T> slice(uint32_t offset_rows, uint32_t new_rows, uint32_t offset_cols, uint32_t new_cols) const {
-		return GPUMatrixDynamic<T>(
-			data() + (layout() == CM ? (offset_rows + offset_cols * m_stride) : (offset_cols + offset_rows * m_stride)),
+		return GPUMatrixDynamic<T>{
+			data() + (layout() == CM ? (offset_rows + offset_cols * stride()) : (offset_cols + offset_rows * stride())),
 			new_rows,
 			new_cols,
 			layout(),
-			stride()
-		);
+			stride(),
+		};
 	}
 
 	GPUMatrixDynamic<T> slice_rows(uint32_t offset, uint32_t size) const {

--- a/src/cutlass_mlp.cu
+++ b/src/cutlass_mlp.cu
@@ -190,8 +190,10 @@ std::unique_ptr<Context> CutlassMLP<T>::forward(cudaStream_t stream, const GPUMa
 	this->check_forward_args(input, output);
 
 	// If there are no hidden layers, the network is just a simple matmul. No tmp buffers required
-	if (output && m_n_hidden_layers == 0) {
-		compute_layer<LastLayer>(stream, false, m_output_activation, input_weight_matrix(use_inference_params), input, *output, *output);
+	if (m_n_hidden_layers == 0) {
+		if (output) {
+			compute_layer<LastLayer>(stream, false, m_output_activation, input_weight_matrix(use_inference_params), input, *output, *output);
+		}
 		return std::make_unique<ForwardContext>(); // Nothing to save -- empty context
 	}
 


### PR DESCRIPTION
- Adds support for strided network outputs in `FullyFusedMLP` (enables certain types of optimizations)
- Fixes a bug in `CutlassMLP::forward` that caused unneeded computation
- Attempts to work around a few instances of internal CUTLASS errors https://github.com/NVlabs/tiny-cuda-nn/issues/61