### PR TITLE
Support row-major (SoA) input and outputs for all `Encoding<T>` implementations

### DIFF
--- a/include/tiny-cuda-nn/encoding.h
+++ b/include/tiny-cuda-nn/encoding.h
@@ -52,7 +52,7 @@ class Encoding : public DifferentiableObject<float, T, T> {
 public:
 	virtual ~Encoding() { }
 
-	void inference_mixed_precision(
+	void inference_mixed_precision_impl(
 		cudaStream_t stream,
 		const GPUMatrixDynamic<float>& input,
 		GPUMatrixDynamic<T>& output,

--- a/include/tiny-cuda-nn/encodings/composite.h
+++ b/include/tiny-cuda-nn/encodings/composite.h
@@ -99,7 +99,7 @@ public:
 		}
 	}
 
-	std::unique_ptr<Context> forward(
+	std::unique_ptr<Context> forward_impl(
 		cudaStream_t stream,
 		const GPUMatrixDynamic<float>& input,
 		GPUMatrixDynamic<T>* output = nullptr,
@@ -143,7 +143,7 @@ public:
 		return forward;
 	}
 
-	void backward(
+	void backward_impl(
 		cudaStream_t stream,
 		const Context& ctx,
 		const GPUMatrixDynamic<float>& input,

--- a/include/tiny-cuda-nn/encodings/frequency.h
+++ b/include/tiny-cuda-nn/encodings/frequency.h
@@ -125,7 +125,7 @@ public:
 		m_n_padded_output_dims = m_n_output_dims = m_n_dims_to_encode * m_n_frequencies * 2;
 	}
 
-	std::unique_ptr<Context> forward(
+	std::unique_ptr<Context> forward_impl(
 		cudaStream_t stream,
 		const GPUMatrixDynamic<float>& input,
 		GPUMatrixDynamic<T>* output = nullptr,
@@ -155,7 +155,7 @@ public:
 		return forward;
 	}
 
-	void backward(
+	void backward_impl(
 		cudaStream_t stream,
 		const Context& ctx,
 		const GPUMatrixDynamic<float>& input,

--- a/include/tiny-cuda-nn/encodings/frequency.h
+++ b/include/tiny-cuda-nn/encodings/frequency.h
@@ -49,8 +49,8 @@ __global__ void frequency_encoding(
 	const uint32_t n_frequencies,
 	const uint32_t num_to_encode,
 	const uint32_t num_to_pad,
-	PitchedPtr<const float> data_in,
-	PitchedPtr<T> data_out,
+	MatrixView<const float> data_in,
+	MatrixView<T> data_out,
 	float* __restrict__ dy_dx)
 {
 	const uint32_t encoded_index = threadIdx.x + blockIdx.x * blockDim.x;
@@ -70,7 +70,7 @@ __global__ void frequency_encoding(
 	 *     padding (value 1.f)
 	 */
 	if (j >= fan_out_encoded) {
-		data_out(i)[j] = 1;
+		data_out(j, i) = 1;
 	} else {
 		/* Layout of encoded features (e.g. when inputs abcd.. are XYZ positions):
 		 *     sin(a.x), cos(a.x) sin(2pi a.x), cos(2pi a.x) sin(4pi a.x) ...
@@ -84,9 +84,9 @@ __global__ void frequency_encoding(
 
 		const float phase_shift = (j % 2) * (PI/2);
 
-		const float x = scalbnf(data_in(i)[encoded_input_feature_i], log2_frequency);
+		const float x = scalbnf(data_in(encoded_input_feature_i, i), log2_frequency);
 		const float input = x * PI + phase_shift;
-		data_out(i)[j] = (T)__sinf(input);
+		data_out(j, i) = (T)__sinf(input);
 		if (dy_dx != nullptr) {
 			dy_dx[i * fan_out_encoded + j] = scalbnf(1.0f, log2_frequency) * PI * __cosf(input);
 		}
@@ -98,9 +98,9 @@ __global__ void frequency_encoding_backward(
 	const uint32_t num_elements,
 	const uint32_t n_dims_to_encode,
 	const uint32_t n_frequencies,
-	PitchedPtr<const T> dL_dy,
+	MatrixView<const T> dL_dy,
 	const float* dy_dx,
-	PitchedPtr<float> dL_dx
+	MatrixView<float> dL_dx
 ) {
 	const uint32_t encoded_index = threadIdx.x + blockIdx.x * blockDim.x;
 	if (encoded_index >= num_elements) return;
@@ -112,9 +112,9 @@ __global__ void frequency_encoding_backward(
 
 	float result = 0;
 	for (int k = 0; k < outputs_per_input; ++k) {
-		result += (float)dL_dy(i)[j * outputs_per_input + k] * dy_dx[i * n_dims_to_encode * outputs_per_input + j * outputs_per_input + k];
+		result += (float)dL_dy(j * outputs_per_input + k, i) * dy_dx[i * n_dims_to_encode * outputs_per_input + j * outputs_per_input + k];
 	}
-	dL_dx(i)[j] = result;
+	dL_dx(j, i) = result;
 }
 
 template <typename T>
@@ -147,8 +147,8 @@ public:
 			m_n_frequencies,
 			m_n_dims_to_encode,
 			m_n_to_pad,
-			input.pitched_ptr(),
-			output->pitched_ptr(),
+			input.view(),
+			output->view(),
 			forward->dy_dx.data()
 		);
 
@@ -175,9 +175,9 @@ public:
 			input.n() * m_n_dims_to_encode,
 			m_n_dims_to_encode,
 			m_n_frequencies,
-			dL_doutput.pitched_ptr(),
+			dL_doutput.view(),
 			forward.dy_dx.data(),
-			dL_dinput->pitched_ptr()
+			dL_dinput->view()
 		);
 	}
 

--- a/include/tiny-cuda-nn/encodings/grid.h
+++ b/include/tiny-cuda-nn/encodings/grid.h
@@ -116,7 +116,7 @@ __device__ inline float random_val(uint32_t seed, uint32_t idx) {
 	return rng.next_float();
 }
 
-template <typename T, uint32_t N_POS_DIMS>
+template <typename T>
 __global__ void extract_position(
 	const uint32_t num_elements,
 	PitchedPtr<const float> data_in,
@@ -143,7 +143,7 @@ __global__ void kernel_grid(
 	const InterpolationType interpolation_type,
 	const GridType grid_type,
 	const T* __restrict__ grid,
-	const float* __restrict__ positions_in,
+	MatrixView<const float> positions_in,
 	T* __restrict__ encoded_positions,
 	float* __restrict__ dy_dx
 ) {
@@ -190,12 +190,12 @@ __global__ void kernel_grid(
 	if (interpolation_type == InterpolationType::Nearest || interpolation_type == InterpolationType::Linear) {
 		#pragma unroll
 		for (uint32_t dim = 0; dim < N_POS_DIMS; ++dim) {
-			pos_fract(positions_in[i + dim * num_elements], &pos[dim], &pos_derivative[dim], &pos_grid[dim], scale, identity_fun, identity_derivative);
+			pos_fract(positions_in(dim, i), &pos[dim], &pos_derivative[dim], &pos_grid[dim], scale, identity_fun, identity_derivative);
 		}
 	} else {
 		#pragma unroll
 		for (uint32_t dim = 0; dim < N_POS_DIMS; ++dim) {
-			pos_fract(positions_in[i + dim * num_elements], &pos[dim], &pos_derivative[dim], &pos_grid[dim], scale, smoothstep, smoothstep_derivative);
+			pos_fract(positions_in(dim, i), &pos[dim], &pos_derivative[dim], &pos_grid[dim], scale, smoothstep, smoothstep_derivative);
 		}
 	}
 
@@ -317,7 +317,7 @@ __global__ void kernel_grid_backward(
 	const InterpolationType interpolation_type,
 	const GridType grid_type,
 	GRAD_T* __restrict__ grid_gradient,
-	const float* __restrict__ positions_in,
+	MatrixView<const float> positions_in,
 	const T* __restrict__ dL_dy
 ) {
 	const uint32_t i = ((blockIdx.x * blockDim.x + threadIdx.x) * N_FEATURES_PER_THREAD) / N_FEATURES_PER_LEVEL;
@@ -370,12 +370,12 @@ __global__ void kernel_grid_backward(
 	if (interpolation_type == InterpolationType::Nearest || interpolation_type == InterpolationType::Linear) {
 		#pragma unroll
 		for (uint32_t dim = 0; dim < N_POS_DIMS; ++dim) {
-			pos_fract(positions_in[i + dim * num_elements], &pos[dim], &pos_grid[dim], scale, identity_fun);
+			pos_fract(positions_in(dim, i), &pos[dim], &pos_grid[dim], scale, identity_fun);
 		}
 	} else {
 		#pragma unroll
 		for (uint32_t dim = 0; dim < N_POS_DIMS; ++dim) {
-			pos_fract(positions_in[i + dim * num_elements], &pos[dim], &pos_grid[dim], scale, smoothstep);
+			pos_fract(positions_in(dim, i), &pos[dim], &pos_grid[dim], scale, smoothstep);
 		}
 	}
 
@@ -465,7 +465,7 @@ __global__ void kernel_grid_backward_input(
 	const uint32_t num_grid_features,
 	const T* dL_dy_rm,
 	const float* __restrict__ dy_dx,
-	PitchedPtr<float> dL_dx
+	MatrixView<float> dL_dx
 ) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= num_elements) return;
@@ -482,7 +482,10 @@ __global__ void kernel_grid_backward_input(
 		}
 	}
 
-	*(vector_fullp_t<N_POS_DIMS>*)dL_dx(i) = result;
+	#pragma unroll
+	for (uint32_t dim = 0; dim < N_POS_DIMS; ++dim) {
+		dL_dx(dim, i) = result[dim];
+	}
 }
 
 template <typename T>
@@ -622,11 +625,6 @@ public:
 			return forward;
 		}
 
-		if (prepare_input_gradients) {
-			forward->dy_dx = GPUMatrix<float, RM>{N_POS_DIMS * m_n_features, input.n(), stream};
-		}
-		forward->positions = GPUMatrix<float, RM>{N_POS_DIMS, input.n(), stream};
-
 		SyncedMultiStream synced_streams{stream, m_n_to_pad > 0 ? 2u : 1u};
 
 		// Take care of padding on the auxiliary stream
@@ -646,16 +644,6 @@ public:
 		// This way, only one level of the hashmap needs to fit into caches at a time (and it reused for consecutive
 		// elements) until it is time to process the next level.
 
-		// First step: extract positional input into consecutive memory for fast reading
-		const dim3 threads = { 64, N_POS_DIMS, 1 };
-		const uint32_t blocks = div_round_up(num_elements, threads.x);
-		extract_position<float, N_POS_DIMS><<<blocks, threads, 0, synced_streams.get(0)>>>(
-			num_elements,
-			input.pitched_ptr(),
-			forward->positions.data()
-		);
-
-		// Second step: compute encoding
 		static constexpr uint32_t N_THREADS_HASHGRID = 512;
 		const dim3 blocks_hashgrid = { div_round_up(num_elements, N_THREADS_HASHGRID), m_n_levels, 1 };
 
@@ -664,6 +652,10 @@ public:
 		if (output && output->layout() == AoS) {
 			workspace = allocate_workspace(stream, num_elements * m_n_features * sizeof(T));
 			encoded_positions_soa = (T*)workspace.data();
+		}
+
+		if (prepare_input_gradients) {
+			forward->dy_dx = GPUMatrix<float, RM>{N_POS_DIMS * m_n_features, input.n(), stream};
 		}
 
 		kernel_grid<T, N_POS_DIMS, N_FEATURES_PER_LEVEL><<<blocks_hashgrid, N_THREADS_HASHGRID, 0, synced_streams.get(0)>>>(
@@ -678,13 +670,13 @@ public:
 			m_interpolation_type,
 			m_grid_type,
 			use_inference_params ? m_grid_inference : m_grid,
-			forward->positions.data(),
+			forward->positions.data() ? forward->positions.view() : input.view(),
 			encoded_positions_soa,
 			forward->dy_dx.data()
 		);
 
 		if (output && output->layout() == AoS) {
-			// Third step: transpose result (was stored row major due to coalescing)
+			// Transpose result (was stored row major due to coalescing)
 			const dim3 threads_transpose = { m_n_levels * N_FEATURES_PER_LEVEL, 8, 1 };
 			const uint32_t blocks_transpose = div_round_up(num_elements, threads_transpose.y);
 			transpose_encoded_position<T><<<blocks_transpose, threads_transpose, 0, synced_streams.get(0)>>>(
@@ -766,7 +758,7 @@ public:
 				m_interpolation_type,
 				m_grid_type,
 				grid_gradient,
-				forward.positions.data(), // positions SoA
+				forward.positions.data() ? forward.positions.view() : input.view(), // positions SoA
 				dL_dy_rm // gradients SoA
 			);
 
@@ -786,7 +778,7 @@ public:
 			m_n_features,
 			dL_dy_rm,
 			forward.dy_dx.data(),
-			dL_dinput->pitched_ptr()
+			dL_dinput->view()
 		);
 	}
 

--- a/include/tiny-cuda-nn/encodings/grid.h
+++ b/include/tiny-cuda-nn/encodings/grid.h
@@ -608,7 +608,7 @@ public:
 		}
 	}
 
-	std::unique_ptr<Context> forward(
+	std::unique_ptr<Context> forward_impl(
 		cudaStream_t stream,
 		const GPUMatrixDynamic<float>& input,
 		GPUMatrixDynamic<T>* output = nullptr,
@@ -697,7 +697,7 @@ public:
 		return forward;
 	}
 
-	void backward(
+	void backward_impl(
 		cudaStream_t stream,
 		const Context& ctx,
 		const GPUMatrixDynamic<float>& input,

--- a/include/tiny-cuda-nn/encodings/identity.h
+++ b/include/tiny-cuda-nn/encodings/identity.h
@@ -101,7 +101,7 @@ public:
 		m_n_padded_output_dims = m_n_output_dims = m_n_dims_to_encode;
 	}
 
-	std::unique_ptr<Context> forward(
+	std::unique_ptr<Context> forward_impl(
 		cudaStream_t stream,
 		const GPUMatrixDynamic<float>& input,
 		GPUMatrixDynamic<T>* output = nullptr,
@@ -127,7 +127,7 @@ public:
 		return std::make_unique<Context>();
 	}
 
-	void backward(
+	void backward_impl(
 		cudaStream_t stream,
 		const Context& ctx,
 		const GPUMatrixDynamic<float>& input,

--- a/include/tiny-cuda-nn/encodings/oneblob.h
+++ b/include/tiny-cuda-nn/encodings/oneblob.h
@@ -192,7 +192,7 @@ public:
 		}
 	}
 
-	std::unique_ptr<Context> forward(
+	std::unique_ptr<Context> forward_impl(
 		cudaStream_t stream,
 		const GPUMatrixDynamic<float>& input,
 		GPUMatrixDynamic<T>* output = nullptr,
@@ -242,7 +242,7 @@ public:
 		return std::make_unique<Context>();
 	}
 
-	void backward(
+	void backward_impl(
 		cudaStream_t stream,
 		const Context& ctx,
 		const GPUMatrixDynamic<float>& input,

--- a/include/tiny-cuda-nn/encodings/oneblob.h
+++ b/include/tiny-cuda-nn/encodings/oneblob.h
@@ -45,10 +45,10 @@
 TCNN_NAMESPACE_BEGIN
 
 template <typename F>
-__device__ inline float one_blob_subwarp_aligned(F kernel, const float* __restrict__ data_in, const uint32_t encoded_index, const uint32_t num_bins_log2) {
+__device__ inline float one_blob_subwarp_aligned(F kernel, MatrixView<const float> data_in, const uint32_t elem_index, const uint32_t encoded_index, const uint32_t num_bins_log2) {
 	const uint32_t n_bins = 1 << num_bins_log2;
 	const uint32_t bin_index = encoded_index & (n_bins - 1);
-	const float x = data_in[encoded_index >> num_bins_log2];
+	const float x = data_in(encoded_index >> num_bins_log2, elem_index);
 
 	const float left_boundary = scalbnf(bin_index, -num_bins_log2);
 	float left_cdf = kernel(left_boundary - x, n_bins) + kernel(left_boundary - x - 1.0f, n_bins) + kernel(left_boundary - x + 1.0f, n_bins);
@@ -88,7 +88,7 @@ __global__ void kernel_one_blob(
 	const uint32_t num_bins_log2,
 	const uint32_t num_to_encode,
 	const uint32_t num_to_pad,
-	PitchedPtr<const float> data_in,
+	MatrixView<const float> data_in,
 	PitchedPtr<T> data_out
 ) {
 	const uint32_t fan_out_encoded = num_to_encode << num_bins_log2;
@@ -103,7 +103,7 @@ __global__ void kernel_one_blob(
 		// A value of 1 here allows the network to learn a bias-like thing.
 		data_out(i)[j] = 1;
 	} else {
-		data_out(i)[j] = (T)one_blob_subwarp_aligned(quartic_cdf, data_in(i), j, num_bins_log2);
+		data_out(i)[j] = (T)one_blob_subwarp_aligned(quartic_cdf, data_in, i, j, num_bins_log2);
 	}
 }
 
@@ -112,7 +112,7 @@ __global__ void kernel_one_blob_soa(
 	const uint32_t num_elements,
 	const uint32_t num_bins_log2,
 	const uint32_t num_to_encode,
-	PitchedPtr<const float> data_in,
+	MatrixView<const float> data_in,
 	T* __restrict__ data_out
 ) {
 	const uint32_t i = blockIdx.x * blockDim.y + threadIdx.y;
@@ -120,7 +120,7 @@ __global__ void kernel_one_blob_soa(
 	const uint32_t to_encode_index = j + i * blockDim.x;
 	if (to_encode_index >= num_elements * num_to_encode) return;
 
-	const float x = data_in(i)[j];
+	const float x = data_in(j, i);
 
 	const uint32_t n_bins = 1 << num_bins_log2;
 	T* out = (data_out + i + j * n_bins * num_elements);
@@ -143,17 +143,16 @@ __global__ void kernel_one_blob_backward(
 	const uint32_t num_elements,
 	const uint32_t n_dims_to_encode,
 	const uint32_t num_bins_log2,
-	MatrixLayout output_layout,
-	PitchedPtr<const T> dL_dy,
-	PitchedPtr<const float> data_in,
-	PitchedPtr<float> dL_dx)
+	MatrixView<const T> dL_dy,
+	MatrixView<const float> data_in,
+	MatrixView<float> dL_dx)
 {
 	const uint32_t i = blockIdx.x * blockDim.y + threadIdx.y;
 	const uint32_t j = threadIdx.x;
 	const uint32_t to_encode_index = j + i * blockDim.x;
 	if (to_encode_index >= num_elements * n_dims_to_encode) return;
 
-	const float x = data_in(i)[j];
+	const float x = data_in(j, i);
 
 	const uint32_t n_bins = 1 << num_bins_log2;
 
@@ -170,12 +169,10 @@ __global__ void kernel_one_blob_backward(
 		left_cdf = right_cdf;
 
 		uint32_t encoded_dim = j * n_bins + k;
-		const T* grad = output_layout == AoS ? &dL_dy(i)[encoded_dim] : (dL_dy.ptr + i + encoded_dim * num_elements);
-
-		result += (float)*grad * deriv;
+		result += (float)dL_dy(encoded_dim, i) * deriv;
 	}
 
-	dL_dx(i)[j] = result;
+	dL_dx(j, i) = result;
 }
 
 template <typename T>
@@ -216,7 +213,7 @@ public:
 				num_bins_log2,
 				m_n_dims_to_encode,
 				m_n_to_pad,
-				input.pitched_ptr(),
+				input.view(),
 				output->pitched_ptr()
 			);
 		} else {
@@ -229,7 +226,7 @@ public:
 				input.n(),
 				num_bins_log2,
 				m_n_dims_to_encode,
-				input.pitched_ptr(),
+				input.view(),
 				output->data()
 			);
 
@@ -256,8 +253,6 @@ public:
 			return;
 		}
 
-		CHECK_THROW(dL_doutput.layout() == output.layout());
-
 		const uint32_t num_bins_log2 = (uint32_t)std::log2(m_n_bins);
 
 		const uint32_t min_n_threads = n_threads_linear;
@@ -269,10 +264,9 @@ public:
 			input.n(),
 			m_n_dims_to_encode,
 			num_bins_log2,
-			output.layout(),
-			dL_doutput.pitched_ptr(),
-			input.pitched_ptr(),
-			dL_dinput->pitched_ptr()
+			dL_doutput.view(),
+			input.view(),
+			dL_dinput->view()
 		);
 	}
 

--- a/include/tiny-cuda-nn/encodings/spherical_harmonics.h
+++ b/include/tiny-cuda-nn/encodings/spherical_harmonics.h
@@ -48,25 +48,24 @@ __global__ void kernel_sh(
 	const uint32_t num_elements,
 	const uint32_t degree,
 	const uint32_t num_to_pad,
-	MatrixLayout output_layout,
-	PitchedPtr<const float> data_in,
-	PitchedPtr<T> data_out
+	MatrixView<const float> data_in,
+	MatrixView<T> data_out
 ) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= num_elements) return;
 
-	PitchedPtr<T> out = output_layout == AoS ? PitchedPtr<T>{data_out(i), 1} : PitchedPtr<T>{data_out.ptr + i, num_elements};
+	data_out.advance_cols(i);
 
 	#pragma unroll
 	for (uint32_t j = 0; j < num_to_pad; ++j) {
-		*out(j) = (T)1.0f;
+		data_out(j) = (T)1.0f;
 	}
 
-	out += num_to_pad;
+	data_out.advance_rows(num_to_pad);
 
-	float x = data_in(i)[0] * 2.f - 1.f;
-	float y = data_in(i)[1] * 2.f - 1.f;
-	float z = data_in(i)[2] * 2.f - 1.f;
+	float x = data_in(0, i) * 2.f - 1.f;
+	float y = data_in(1, i) * 2.f - 1.f;
+	float z = data_in(2, i) * 2.f - 1.f;
 
 	// Let compiler figure out how to sequence/reorder these calculations w.r.t. branches
 	float xy=x*y, xz=x*z, yz=y*z, x2=x*x, y2=y*y, z2=z*z;
@@ -76,77 +75,77 @@ __global__ void kernel_sh(
 	// SH polynomials generated using scripts/gen_sh.py based on the recurrence relations in appendix A1 of https://www.ppsloan.org/publications/StupidSH36.pdf
 
 	auto write_sh = [&]() {
-		*out(0) = 0.28209479177387814f;                          // 1/(2*sqrt(pi))
+		data_out(0) = 0.28209479177387814f;                          // 1/(2*sqrt(pi))
 		if (degree <= 1) { return; }
-		*out(1) = -0.48860251190291987f*y;                               // -sqrt(3)*y/(2*sqrt(pi))
-		*out(2) = 0.48860251190291987f*z;                                // sqrt(3)*z/(2*sqrt(pi))
-		*out(3) = -0.48860251190291987f*x;                               // -sqrt(3)*x/(2*sqrt(pi))
+		data_out(1) = -0.48860251190291987f*y;                               // -sqrt(3)*y/(2*sqrt(pi))
+		data_out(2) = 0.48860251190291987f*z;                                // sqrt(3)*z/(2*sqrt(pi))
+		data_out(3) = -0.48860251190291987f*x;                               // -sqrt(3)*x/(2*sqrt(pi))
 		if (degree <= 2) { return; }
-		*out(4) = 1.0925484305920792f*xy;                                // sqrt(15)*xy/(2*sqrt(pi))
-		*out(5) = -1.0925484305920792f*yz;                               // -sqrt(15)*yz/(2*sqrt(pi))
-		*out(6) = 0.94617469575755997f*z2 - 0.31539156525251999f;                         // sqrt(5)*(3*z2 - 1)/(4*sqrt(pi))
-		*out(7) = -1.0925484305920792f*xz;                               // -sqrt(15)*xz/(2*sqrt(pi))
-		*out(8) = 0.54627421529603959f*x2 - 0.54627421529603959f*y2;                              // sqrt(15)*(x2 - y2)/(4*sqrt(pi))
+		data_out(4) = 1.0925484305920792f*xy;                                // sqrt(15)*xy/(2*sqrt(pi))
+		data_out(5) = -1.0925484305920792f*yz;                               // -sqrt(15)*yz/(2*sqrt(pi))
+		data_out(6) = 0.94617469575755997f*z2 - 0.31539156525251999f;                         // sqrt(5)*(3*z2 - 1)/(4*sqrt(pi))
+		data_out(7) = -1.0925484305920792f*xz;                               // -sqrt(15)*xz/(2*sqrt(pi))
+		data_out(8) = 0.54627421529603959f*x2 - 0.54627421529603959f*y2;                              // sqrt(15)*(x2 - y2)/(4*sqrt(pi))
 		if (degree <= 3) { return; }
-		*out(9) = 0.59004358992664352f*y*(-3.0f*x2 + y2);                         // sqrt(70)*y*(-3*x2 + y2)/(8*sqrt(pi))
-		*out(10) = 2.8906114426405538f*xy*z;                             // sqrt(105)*xy*z/(2*sqrt(pi))
-		*out(11) = 0.45704579946446572f*y*(1.0f - 5.0f*z2);                                // sqrt(42)*y*(1 - 5*z2)/(8*sqrt(pi))
-		*out(12) = 0.3731763325901154f*z*(5.0f*z2 - 3.0f);                         // sqrt(7)*z*(5*z2 - 3)/(4*sqrt(pi))
-		*out(13) = 0.45704579946446572f*x*(1.0f - 5.0f*z2);                                // sqrt(42)*x*(1 - 5*z2)/(8*sqrt(pi))
-		*out(14) = 1.4453057213202769f*z*(x2 - y2);                              // sqrt(105)*z*(x2 - y2)/(4*sqrt(pi))
-		*out(15) = 0.59004358992664352f*x*(-x2 + 3.0f*y2);                                // sqrt(70)*x*(-x2 + 3*y2)/(8*sqrt(pi))
+		data_out(9) = 0.59004358992664352f*y*(-3.0f*x2 + y2);                         // sqrt(70)*y*(-3*x2 + y2)/(8*sqrt(pi))
+		data_out(10) = 2.8906114426405538f*xy*z;                             // sqrt(105)*xy*z/(2*sqrt(pi))
+		data_out(11) = 0.45704579946446572f*y*(1.0f - 5.0f*z2);                                // sqrt(42)*y*(1 - 5*z2)/(8*sqrt(pi))
+		data_out(12) = 0.3731763325901154f*z*(5.0f*z2 - 3.0f);                         // sqrt(7)*z*(5*z2 - 3)/(4*sqrt(pi))
+		data_out(13) = 0.45704579946446572f*x*(1.0f - 5.0f*z2);                                // sqrt(42)*x*(1 - 5*z2)/(8*sqrt(pi))
+		data_out(14) = 1.4453057213202769f*z*(x2 - y2);                              // sqrt(105)*z*(x2 - y2)/(4*sqrt(pi))
+		data_out(15) = 0.59004358992664352f*x*(-x2 + 3.0f*y2);                                // sqrt(70)*x*(-x2 + 3*y2)/(8*sqrt(pi))
 		if (degree <= 4) { return; }
-		*out(16) = 2.5033429417967046f*xy*(x2 - y2);                             // 3*sqrt(35)*xy*(x2 - y2)/(4*sqrt(pi))
-		*out(17) = 1.7701307697799304f*yz*(-3.0f*x2 + y2);                                // 3*sqrt(70)*yz*(-3*x2 + y2)/(8*sqrt(pi))
-		*out(18) = 0.94617469575756008f*xy*(7.0f*z2 - 1.0f);                               // 3*sqrt(5)*xy*(7*z2 - 1)/(4*sqrt(pi))
-		*out(19) = 0.66904654355728921f*yz*(3.0f - 7.0f*z2);                               // 3*sqrt(10)*yz*(3 - 7*z2)/(8*sqrt(pi))
-		*out(20) = -3.1735664074561294f*z2 + 3.7024941420321507f*z4 + 0.31735664074561293f;                                // 3*(-30*z2 + 35*z4 + 3)/(16*sqrt(pi))
-		*out(21) = 0.66904654355728921f*xz*(3.0f - 7.0f*z2);                               // 3*sqrt(10)*xz*(3 - 7*z2)/(8*sqrt(pi))
-		*out(22) = 0.47308734787878004f*(x2 - y2)*(7.0f*z2 - 1.0f);                                // 3*sqrt(5)*(x2 - y2)*(7*z2 - 1)/(8*sqrt(pi))
-		*out(23) = 1.7701307697799304f*xz*(-x2 + 3.0f*y2);                                // 3*sqrt(70)*xz*(-x2 + 3*y2)/(8*sqrt(pi))
-		*out(24) = -3.7550144126950569f*x2*y2 + 0.62583573544917614f*x4 + 0.62583573544917614f*y4;                         // 3*sqrt(35)*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
+		data_out(16) = 2.5033429417967046f*xy*(x2 - y2);                             // 3*sqrt(35)*xy*(x2 - y2)/(4*sqrt(pi))
+		data_out(17) = 1.7701307697799304f*yz*(-3.0f*x2 + y2);                                // 3*sqrt(70)*yz*(-3*x2 + y2)/(8*sqrt(pi))
+		data_out(18) = 0.94617469575756008f*xy*(7.0f*z2 - 1.0f);                               // 3*sqrt(5)*xy*(7*z2 - 1)/(4*sqrt(pi))
+		data_out(19) = 0.66904654355728921f*yz*(3.0f - 7.0f*z2);                               // 3*sqrt(10)*yz*(3 - 7*z2)/(8*sqrt(pi))
+		data_out(20) = -3.1735664074561294f*z2 + 3.7024941420321507f*z4 + 0.31735664074561293f;                                // 3*(-30*z2 + 35*z4 + 3)/(16*sqrt(pi))
+		data_out(21) = 0.66904654355728921f*xz*(3.0f - 7.0f*z2);                               // 3*sqrt(10)*xz*(3 - 7*z2)/(8*sqrt(pi))
+		data_out(22) = 0.47308734787878004f*(x2 - y2)*(7.0f*z2 - 1.0f);                                // 3*sqrt(5)*(x2 - y2)*(7*z2 - 1)/(8*sqrt(pi))
+		data_out(23) = 1.7701307697799304f*xz*(-x2 + 3.0f*y2);                                // 3*sqrt(70)*xz*(-x2 + 3*y2)/(8*sqrt(pi))
+		data_out(24) = -3.7550144126950569f*x2*y2 + 0.62583573544917614f*x4 + 0.62583573544917614f*y4;                         // 3*sqrt(35)*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
 		if (degree <= 5) { return; }
-		*out(25) = 0.65638205684017015f*y*(10.0f*x2*y2 - 5.0f*x4 - y4);                            // 3*sqrt(154)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		*out(26) = 8.3026492595241645f*xy*z*(x2 - y2);                           // 3*sqrt(385)*xy*z*(x2 - y2)/(4*sqrt(pi))
-		*out(27) = -0.48923829943525038f*y*(3.0f*x2 - y2)*(9.0f*z2 - 1.0f);                         // -sqrt(770)*y*(3*x2 - y2)*(9*z2 - 1)/(32*sqrt(pi))
-		*out(28) = 4.7935367849733241f*xy*z*(3.0f*z2 - 1.0f);                              // sqrt(1155)*xy*z*(3*z2 - 1)/(4*sqrt(pi))
-		*out(29) = 0.45294665119569694f*y*(14.0f*z2 - 21.0f*z4 - 1.0f);                             // sqrt(165)*y*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
-		*out(30) = 0.1169503224534236f*z*(-70.0f*z2 + 63.0f*z4 + 15.0f);                            // sqrt(11)*z*(-70*z2 + 63*z4 + 15)/(16*sqrt(pi))
-		*out(31) = 0.45294665119569694f*x*(14.0f*z2 - 21.0f*z4 - 1.0f);                             // sqrt(165)*x*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
-		*out(32) = 2.3967683924866621f*z*(x2 - y2)*(3.0f*z2 - 1.0f);                               // sqrt(1155)*z*(x2 - y2)*(3*z2 - 1)/(8*sqrt(pi))
-		*out(33) = -0.48923829943525038f*x*(x2 - 3.0f*y2)*(9.0f*z2 - 1.0f);                         // -sqrt(770)*x*(x2 - 3*y2)*(9*z2 - 1)/(32*sqrt(pi))
-		*out(34) = 2.0756623148810411f*z*(-6.0f*x2*y2 + x4 + y4);                         // 3*sqrt(385)*z*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
-		*out(35) = 0.65638205684017015f*x*(10.0f*x2*y2 - x4 - 5.0f*y4);                            // 3*sqrt(154)*x*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
+		data_out(25) = 0.65638205684017015f*y*(10.0f*x2*y2 - 5.0f*x4 - y4);                            // 3*sqrt(154)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		data_out(26) = 8.3026492595241645f*xy*z*(x2 - y2);                           // 3*sqrt(385)*xy*z*(x2 - y2)/(4*sqrt(pi))
+		data_out(27) = -0.48923829943525038f*y*(3.0f*x2 - y2)*(9.0f*z2 - 1.0f);                         // -sqrt(770)*y*(3*x2 - y2)*(9*z2 - 1)/(32*sqrt(pi))
+		data_out(28) = 4.7935367849733241f*xy*z*(3.0f*z2 - 1.0f);                              // sqrt(1155)*xy*z*(3*z2 - 1)/(4*sqrt(pi))
+		data_out(29) = 0.45294665119569694f*y*(14.0f*z2 - 21.0f*z4 - 1.0f);                             // sqrt(165)*y*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
+		data_out(30) = 0.1169503224534236f*z*(-70.0f*z2 + 63.0f*z4 + 15.0f);                            // sqrt(11)*z*(-70*z2 + 63*z4 + 15)/(16*sqrt(pi))
+		data_out(31) = 0.45294665119569694f*x*(14.0f*z2 - 21.0f*z4 - 1.0f);                             // sqrt(165)*x*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
+		data_out(32) = 2.3967683924866621f*z*(x2 - y2)*(3.0f*z2 - 1.0f);                               // sqrt(1155)*z*(x2 - y2)*(3*z2 - 1)/(8*sqrt(pi))
+		data_out(33) = -0.48923829943525038f*x*(x2 - 3.0f*y2)*(9.0f*z2 - 1.0f);                         // -sqrt(770)*x*(x2 - 3*y2)*(9*z2 - 1)/(32*sqrt(pi))
+		data_out(34) = 2.0756623148810411f*z*(-6.0f*x2*y2 + x4 + y4);                         // 3*sqrt(385)*z*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
+		data_out(35) = 0.65638205684017015f*x*(10.0f*x2*y2 - x4 - 5.0f*y4);                            // 3*sqrt(154)*x*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
 		if (degree <= 6) { return; }
-		*out(36) = 1.3663682103838286f*xy*(-10.0f*x2*y2 + 3.0f*x4 + 3.0f*y4);                               // sqrt(6006)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
-		*out(37) = 2.3666191622317521f*yz*(10.0f*x2*y2 - 5.0f*x4 - y4);                            // 3*sqrt(2002)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		*out(38) = 2.0182596029148963f*xy*(x2 - y2)*(11.0f*z2 - 1.0f);                             // 3*sqrt(91)*xy*(x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
-		*out(39) = -0.92120525951492349f*yz*(3.0f*x2 - y2)*(11.0f*z2 - 3.0f);                               // -sqrt(2730)*yz*(3*x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
-		*out(40) = 0.92120525951492349f*xy*(-18.0f*z2 + 33.0f*z4 + 1.0f);                           // sqrt(2730)*xy*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
-		*out(41) = 0.58262136251873131f*yz*(30.0f*z2 - 33.0f*z4 - 5.0f);                            // sqrt(273)*yz*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
-		*out(42) = 6.6747662381009842f*z2 - 20.024298714302954f*z4 + 14.684485723822165f*z6 - 0.31784601133814211f;                         // sqrt(13)*(105*z2 - 315*z4 + 231*z6 - 5)/(32*sqrt(pi))
-		*out(43) = 0.58262136251873131f*xz*(30.0f*z2 - 33.0f*z4 - 5.0f);                            // sqrt(273)*xz*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
-		*out(44) = 0.46060262975746175f*(x2 - y2)*(11.0f*z2*(3.0f*z2 - 1.0f) - 7.0f*z2 + 1.0f);                               // sqrt(2730)*(x2 - y2)*(11*z2*(3*z2 - 1) - 7*z2 + 1)/(64*sqrt(pi))
-		*out(45) = -0.92120525951492349f*xz*(x2 - 3.0f*y2)*(11.0f*z2 - 3.0f);                               // -sqrt(2730)*xz*(x2 - 3*y2)*(11*z2 - 3)/(32*sqrt(pi))
-		*out(46) = 0.50456490072872406f*(11.0f*z2 - 1.0f)*(-6.0f*x2*y2 + x4 + y4);                          // 3*sqrt(91)*(11*z2 - 1)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
-		*out(47) = 2.3666191622317521f*xz*(10.0f*x2*y2 - x4 - 5.0f*y4);                            // 3*sqrt(2002)*xz*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
-		*out(48) = 10.247761577878714f*x2*y4 - 10.247761577878714f*x4*y2 + 0.6831841051919143f*x6 - 0.6831841051919143f*y6;                         // sqrt(6006)*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
+		data_out(36) = 1.3663682103838286f*xy*(-10.0f*x2*y2 + 3.0f*x4 + 3.0f*y4);                               // sqrt(6006)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
+		data_out(37) = 2.3666191622317521f*yz*(10.0f*x2*y2 - 5.0f*x4 - y4);                            // 3*sqrt(2002)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		data_out(38) = 2.0182596029148963f*xy*(x2 - y2)*(11.0f*z2 - 1.0f);                             // 3*sqrt(91)*xy*(x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
+		data_out(39) = -0.92120525951492349f*yz*(3.0f*x2 - y2)*(11.0f*z2 - 3.0f);                               // -sqrt(2730)*yz*(3*x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
+		data_out(40) = 0.92120525951492349f*xy*(-18.0f*z2 + 33.0f*z4 + 1.0f);                           // sqrt(2730)*xy*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
+		data_out(41) = 0.58262136251873131f*yz*(30.0f*z2 - 33.0f*z4 - 5.0f);                            // sqrt(273)*yz*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
+		data_out(42) = 6.6747662381009842f*z2 - 20.024298714302954f*z4 + 14.684485723822165f*z6 - 0.31784601133814211f;                         // sqrt(13)*(105*z2 - 315*z4 + 231*z6 - 5)/(32*sqrt(pi))
+		data_out(43) = 0.58262136251873131f*xz*(30.0f*z2 - 33.0f*z4 - 5.0f);                            // sqrt(273)*xz*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
+		data_out(44) = 0.46060262975746175f*(x2 - y2)*(11.0f*z2*(3.0f*z2 - 1.0f) - 7.0f*z2 + 1.0f);                               // sqrt(2730)*(x2 - y2)*(11*z2*(3*z2 - 1) - 7*z2 + 1)/(64*sqrt(pi))
+		data_out(45) = -0.92120525951492349f*xz*(x2 - 3.0f*y2)*(11.0f*z2 - 3.0f);                               // -sqrt(2730)*xz*(x2 - 3*y2)*(11*z2 - 3)/(32*sqrt(pi))
+		data_out(46) = 0.50456490072872406f*(11.0f*z2 - 1.0f)*(-6.0f*x2*y2 + x4 + y4);                          // 3*sqrt(91)*(11*z2 - 1)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
+		data_out(47) = 2.3666191622317521f*xz*(10.0f*x2*y2 - x4 - 5.0f*y4);                            // 3*sqrt(2002)*xz*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
+		data_out(48) = 10.247761577878714f*x2*y4 - 10.247761577878714f*x4*y2 + 0.6831841051919143f*x6 - 0.6831841051919143f*y6;                         // sqrt(6006)*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
 		if (degree <= 7) { return; }
-		*out(49) = 0.70716273252459627f*y*(-21.0f*x2*y4 + 35.0f*x4*y2 - 7.0f*x6 + y6);                              // 3*sqrt(715)*y*(-21*x2*y4 + 35*x4*y2 - 7*x6 + y6)/(64*sqrt(pi))
-		*out(50) = 5.2919213236038001f*xy*z*(-10.0f*x2*y2 + 3.0f*x4 + 3.0f*y4);                             // 3*sqrt(10010)*xy*z*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
-		*out(51) = -0.51891557872026028f*y*(13.0f*z2 - 1.0f)*(-10.0f*x2*y2 + 5.0f*x4 + y4);                          // -3*sqrt(385)*y*(13*z2 - 1)*(-10*x2*y2 + 5*x4 + y4)/(64*sqrt(pi))
-		*out(52) = 4.1513246297620823f*xy*z*(x2 - y2)*(13.0f*z2 - 3.0f);                           // 3*sqrt(385)*xy*z*(x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
-		*out(53) = -0.15645893386229404f*y*(3.0f*x2 - y2)*(13.0f*z2*(11.0f*z2 - 3.0f) - 27.0f*z2 + 3.0f);                              // -3*sqrt(35)*y*(3*x2 - y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
-		*out(54) = 0.44253269244498261f*xy*z*(-110.0f*z2 + 143.0f*z4 + 15.0f);                              // 3*sqrt(70)*xy*z*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
-		*out(55) = 0.090331607582517306f*y*(-135.0f*z2 + 495.0f*z4 - 429.0f*z6 + 5.0f);                              // sqrt(105)*y*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
-		*out(56) = 0.068284276912004949f*z*(315.0f*z2 - 693.0f*z4 + 429.0f*z6 - 35.0f);                              // sqrt(15)*z*(315*z2 - 693*z4 + 429*z6 - 35)/(32*sqrt(pi))
-		*out(57) = 0.090331607582517306f*x*(-135.0f*z2 + 495.0f*z4 - 429.0f*z6 + 5.0f);                              // sqrt(105)*x*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
-		*out(58) = 0.07375544874083044f*z*(x2 - y2)*(143.0f*z2*(3.0f*z2 - 1.0f) - 187.0f*z2 + 45.0f);                         // sqrt(70)*z*(x2 - y2)*(143*z2*(3*z2 - 1) - 187*z2 + 45)/(64*sqrt(pi))
-		*out(59) = -0.15645893386229404f*x*(x2 - 3.0f*y2)*(13.0f*z2*(11.0f*z2 - 3.0f) - 27.0f*z2 + 3.0f);                              // -3*sqrt(35)*x*(x2 - 3*y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
-		*out(60) = 1.0378311574405206f*z*(13.0f*z2 - 3.0f)*(-6.0f*x2*y2 + x4 + y4);                         // 3*sqrt(385)*z*(13*z2 - 3)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
-		*out(61) = -0.51891557872026028f*x*(13.0f*z2 - 1.0f)*(-10.0f*x2*y2 + x4 + 5.0f*y4);                          // -3*sqrt(385)*x*(13*z2 - 1)*(-10*x2*y2 + x4 + 5*y4)/(64*sqrt(pi))
-		*out(62) = 2.6459606618019f*z*(15.0f*x2*y4 - 15.0f*x4*y2 + x6 - y6);                               // 3*sqrt(10010)*z*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
-		*out(63) = 0.70716273252459627f*x*(-35.0f*x2*y4 + 21.0f*x4*y2 - x6 + 7.0f*y6);                              // 3*sqrt(715)*x*(-35*x2*y4 + 21*x4*y2 - x6 + 7*y6)/(64*sqrt(pi))
+		data_out(49) = 0.70716273252459627f*y*(-21.0f*x2*y4 + 35.0f*x4*y2 - 7.0f*x6 + y6);                              // 3*sqrt(715)*y*(-21*x2*y4 + 35*x4*y2 - 7*x6 + y6)/(64*sqrt(pi))
+		data_out(50) = 5.2919213236038001f*xy*z*(-10.0f*x2*y2 + 3.0f*x4 + 3.0f*y4);                             // 3*sqrt(10010)*xy*z*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
+		data_out(51) = -0.51891557872026028f*y*(13.0f*z2 - 1.0f)*(-10.0f*x2*y2 + 5.0f*x4 + y4);                          // -3*sqrt(385)*y*(13*z2 - 1)*(-10*x2*y2 + 5*x4 + y4)/(64*sqrt(pi))
+		data_out(52) = 4.1513246297620823f*xy*z*(x2 - y2)*(13.0f*z2 - 3.0f);                           // 3*sqrt(385)*xy*z*(x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
+		data_out(53) = -0.15645893386229404f*y*(3.0f*x2 - y2)*(13.0f*z2*(11.0f*z2 - 3.0f) - 27.0f*z2 + 3.0f);                              // -3*sqrt(35)*y*(3*x2 - y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
+		data_out(54) = 0.44253269244498261f*xy*z*(-110.0f*z2 + 143.0f*z4 + 15.0f);                              // 3*sqrt(70)*xy*z*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
+		data_out(55) = 0.090331607582517306f*y*(-135.0f*z2 + 495.0f*z4 - 429.0f*z6 + 5.0f);                              // sqrt(105)*y*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
+		data_out(56) = 0.068284276912004949f*z*(315.0f*z2 - 693.0f*z4 + 429.0f*z6 - 35.0f);                              // sqrt(15)*z*(315*z2 - 693*z4 + 429*z6 - 35)/(32*sqrt(pi))
+		data_out(57) = 0.090331607582517306f*x*(-135.0f*z2 + 495.0f*z4 - 429.0f*z6 + 5.0f);                              // sqrt(105)*x*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
+		data_out(58) = 0.07375544874083044f*z*(x2 - y2)*(143.0f*z2*(3.0f*z2 - 1.0f) - 187.0f*z2 + 45.0f);                         // sqrt(70)*z*(x2 - y2)*(143*z2*(3*z2 - 1) - 187*z2 + 45)/(64*sqrt(pi))
+		data_out(59) = -0.15645893386229404f*x*(x2 - 3.0f*y2)*(13.0f*z2*(11.0f*z2 - 3.0f) - 27.0f*z2 + 3.0f);                              // -3*sqrt(35)*x*(x2 - 3*y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
+		data_out(60) = 1.0378311574405206f*z*(13.0f*z2 - 3.0f)*(-6.0f*x2*y2 + x4 + y4);                         // 3*sqrt(385)*z*(13*z2 - 3)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
+		data_out(61) = -0.51891557872026028f*x*(13.0f*z2 - 1.0f)*(-10.0f*x2*y2 + x4 + 5.0f*y4);                          // -3*sqrt(385)*x*(13*z2 - 1)*(-10*x2*y2 + x4 + 5*y4)/(64*sqrt(pi))
+		data_out(62) = 2.6459606618019f*z*(15.0f*x2*y4 - 15.0f*x4*y2 + x6 - y6);                               // 3*sqrt(10010)*z*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
+		data_out(63) = 0.70716273252459627f*x*(-35.0f*x2*y4 + 21.0f*x4*y2 - x6 + 7.0f*y6);                              // 3*sqrt(715)*x*(-35*x2*y4 + 21*x4*y2 - x6 + 7*y6)/(64*sqrt(pi))
 	};
 
 	write_sh();
@@ -157,21 +156,18 @@ __global__ void kernel_sh_backward(
 	const uint32_t num_elements,
 	const uint32_t degree,
 	const uint32_t num_to_pad,
-	MatrixLayout output_layout,
-	PitchedPtr<const T> dL_dy,
-	PitchedPtr<const float> data_in,
-	PitchedPtr<float> dL_dx
+	MatrixView<const T> dL_dy,
+	MatrixView<const float> data_in,
+	MatrixView<float> dL_dx
 ) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= num_elements) return;
 
-	PitchedPtr<const T> grad = output_layout == AoS ? PitchedPtr<const T>{dL_dy(i), 1} : PitchedPtr<const T>{dL_dy.ptr + i, num_elements};
+	dL_dy.advance(num_to_pad, i);
 
-	grad += num_to_pad;
-
-	float x = data_in(i)[0] * 2.f - 1.f;
-	float y = data_in(i)[1] * 2.f - 1.f;
-	float z = data_in(i)[2] * 2.f - 1.f;
+	float x = data_in(0, i) * 2.f - 1.f;
+	float y = data_in(1, i) * 2.f - 1.f;
+	float z = data_in(2, i) * 2.f - 1.f;
 
 	// Let compiler figure out how to sequence/reorder these calculations w.r.t. branches
 	float xy=x*y, xz=x*z, yz=y*z, x2=x*x, y2=y*y, z2=z*z;
@@ -183,205 +179,205 @@ __global__ void kernel_sh_backward(
 	float dz = 0.0f;
 
 	auto compute_grad = [&]() {
-		// dx += (float)*grad(0) * (0);                                // 0
-		// dy += (float)*grad(0) * (0);                                // 0
-		// dz += (float)*grad(0) * (0);                                // 0
+		// dx += (float)dL_dy(0) * (0);                                // 0
+		// dy += (float)dL_dy(0) * (0);                                // 0
+		// dz += (float)dL_dy(0) * (0);                                // 0
 		if (degree <= 1) { return; }
-		// dx += (float)*grad(1) * (0);                                // 0
-		dy += (float)*grad(1) * (-0.48860251190291992);                                // -sqrt(3)/(2*sqrt(pi))
-		// dz += (float)*grad(1) * (0);                                // 0
-		// dx += (float)*grad(2) * (0);                                // 0
-		// dy += (float)*grad(2) * (0);                                // 0
-		dz += (float)*grad(2) * (0.48860251190291992);                         // sqrt(3)/(2*sqrt(pi))
-		dx += (float)*grad(3) * (-0.48860251190291992);                                // -sqrt(3)/(2*sqrt(pi))
-		// dy += (float)*grad(3) * (0);                                // 0
-		// dz += (float)*grad(3) * (0);                                // 0
+		// dx += (float)dL_dy(1) * (0);                                // 0
+		dy += (float)dL_dy(1) * (-0.48860251190291992);                                // -sqrt(3)/(2*sqrt(pi))
+		// dz += (float)dL_dy(1) * (0);                                // 0
+		// dx += (float)dL_dy(2) * (0);                                // 0
+		// dy += (float)dL_dy(2) * (0);                                // 0
+		dz += (float)dL_dy(2) * (0.48860251190291992);                         // sqrt(3)/(2*sqrt(pi))
+		dx += (float)dL_dy(3) * (-0.48860251190291992);                                // -sqrt(3)/(2*sqrt(pi))
+		// dy += (float)dL_dy(3) * (0);                                // 0
+		// dz += (float)dL_dy(3) * (0);                                // 0
 		if (degree <= 2) { return; }
-		dx += (float)*grad(4) * (1.0925484305920792*y);                                // sqrt(15)*y/(2*sqrt(pi))
-		dy += (float)*grad(4) * (1.0925484305920792*x);                                // sqrt(15)*x/(2*sqrt(pi))
-		// dz += (float)*grad(4) * (0);                                // 0
-		// dx += (float)*grad(5) * (0);                                // 0
-		dy += (float)*grad(5) * (-1.0925484305920792*z);                               // -sqrt(15)*z/(2*sqrt(pi))
-		dz += (float)*grad(5) * (-1.0925484305920792*y);                               // -sqrt(15)*y/(2*sqrt(pi))
-		// dx += (float)*grad(6) * (0);                                // 0
-		// dy += (float)*grad(6) * (0);                                // 0
-		dz += (float)*grad(6) * (1.8923493915151202*z);                                // 3*sqrt(5)*z/(2*sqrt(pi))
-		dx += (float)*grad(7) * (-1.0925484305920792*z);                               // -sqrt(15)*z/(2*sqrt(pi))
-		// dy += (float)*grad(7) * (0);                                // 0
-		dz += (float)*grad(7) * (-1.0925484305920792*x);                               // -sqrt(15)*x/(2*sqrt(pi))
-		dx += (float)*grad(8) * (1.0925484305920792*x);                                // sqrt(15)*x/(2*sqrt(pi))
-		dy += (float)*grad(8) * (-1.0925484305920792*y);                               // -sqrt(15)*y/(2*sqrt(pi))
-		// dz += (float)*grad(8) * (0);                                // 0
+		dx += (float)dL_dy(4) * (1.0925484305920792*y);                                // sqrt(15)*y/(2*sqrt(pi))
+		dy += (float)dL_dy(4) * (1.0925484305920792*x);                                // sqrt(15)*x/(2*sqrt(pi))
+		// dz += (float)dL_dy(4) * (0);                                // 0
+		// dx += (float)dL_dy(5) * (0);                                // 0
+		dy += (float)dL_dy(5) * (-1.0925484305920792*z);                               // -sqrt(15)*z/(2*sqrt(pi))
+		dz += (float)dL_dy(5) * (-1.0925484305920792*y);                               // -sqrt(15)*y/(2*sqrt(pi))
+		// dx += (float)dL_dy(6) * (0);                                // 0
+		// dy += (float)dL_dy(6) * (0);                                // 0
+		dz += (float)dL_dy(6) * (1.8923493915151202*z);                                // 3*sqrt(5)*z/(2*sqrt(pi))
+		dx += (float)dL_dy(7) * (-1.0925484305920792*z);                               // -sqrt(15)*z/(2*sqrt(pi))
+		// dy += (float)dL_dy(7) * (0);                                // 0
+		dz += (float)dL_dy(7) * (-1.0925484305920792*x);                               // -sqrt(15)*x/(2*sqrt(pi))
+		dx += (float)dL_dy(8) * (1.0925484305920792*x);                                // sqrt(15)*x/(2*sqrt(pi))
+		dy += (float)dL_dy(8) * (-1.0925484305920792*y);                               // -sqrt(15)*y/(2*sqrt(pi))
+		// dz += (float)dL_dy(8) * (0);                                // 0
 		if (degree <= 3) { return; }
-		dx += (float)*grad(9) * (-3.5402615395598609*xy);                              // -3*sqrt(70)*xy/(4*sqrt(pi))
-		dy += (float)*grad(9) * (-1.7701307697799304*x2 + 1.7701307697799304*y2);                              // 3*sqrt(70)*(-x2 + y2)/(8*sqrt(pi))
-		// dz += (float)*grad(9) * (0);                                // 0
-		dx += (float)*grad(10) * (2.8906114426405538*yz);                              // sqrt(105)*yz/(2*sqrt(pi))
-		dy += (float)*grad(10) * (2.8906114426405538*xz);                              // sqrt(105)*xz/(2*sqrt(pi))
-		dz += (float)*grad(10) * (2.8906114426405538*xy);                              // sqrt(105)*xy/(2*sqrt(pi))
-		// dx += (float)*grad(11) * (0);                               // 0
-		dy += (float)*grad(11) * (0.45704579946446572 - 2.2852289973223288*z2);                                // sqrt(42)*(1 - 5*z2)/(8*sqrt(pi))
-		dz += (float)*grad(11) * (-4.5704579946446566*yz);                             // -5*sqrt(42)*yz/(4*sqrt(pi))
-		// dx += (float)*grad(12) * (0);                               // 0
-		// dy += (float)*grad(12) * (0);                               // 0
-		dz += (float)*grad(12) * (5.597644988851731*z2 - 1.1195289977703462);                          // 3*sqrt(7)*(5*z2 - 1)/(4*sqrt(pi))
-		dx += (float)*grad(13) * (0.45704579946446572 - 2.2852289973223288*z2);                                // sqrt(42)*(1 - 5*z2)/(8*sqrt(pi))
-		// dy += (float)*grad(13) * (0);                               // 0
-		dz += (float)*grad(13) * (-4.5704579946446566*xz);                             // -5*sqrt(42)*xz/(4*sqrt(pi))
-		dx += (float)*grad(14) * (2.8906114426405538*xz);                              // sqrt(105)*xz/(2*sqrt(pi))
-		dy += (float)*grad(14) * (-2.8906114426405538*yz);                             // -sqrt(105)*yz/(2*sqrt(pi))
-		dz += (float)*grad(14) * (1.4453057213202769*x2 - 1.4453057213202769*y2);                              // sqrt(105)*(x2 - y2)/(4*sqrt(pi))
-		dx += (float)*grad(15) * (-1.7701307697799304*x2 + 1.7701307697799304*y2);                             // 3*sqrt(70)*(-x2 + y2)/(8*sqrt(pi))
-		dy += (float)*grad(15) * (3.5402615395598609*xy);                              // 3*sqrt(70)*xy/(4*sqrt(pi))
-		// dz += (float)*grad(15) * (0);                               // 0
+		dx += (float)dL_dy(9) * (-3.5402615395598609*xy);                              // -3*sqrt(70)*xy/(4*sqrt(pi))
+		dy += (float)dL_dy(9) * (-1.7701307697799304*x2 + 1.7701307697799304*y2);                              // 3*sqrt(70)*(-x2 + y2)/(8*sqrt(pi))
+		// dz += (float)dL_dy(9) * (0);                                // 0
+		dx += (float)dL_dy(10) * (2.8906114426405538*yz);                              // sqrt(105)*yz/(2*sqrt(pi))
+		dy += (float)dL_dy(10) * (2.8906114426405538*xz);                              // sqrt(105)*xz/(2*sqrt(pi))
+		dz += (float)dL_dy(10) * (2.8906114426405538*xy);                              // sqrt(105)*xy/(2*sqrt(pi))
+		// dx += (float)dL_dy(11) * (0);                               // 0
+		dy += (float)dL_dy(11) * (0.45704579946446572 - 2.2852289973223288*z2);                                // sqrt(42)*(1 - 5*z2)/(8*sqrt(pi))
+		dz += (float)dL_dy(11) * (-4.5704579946446566*yz);                             // -5*sqrt(42)*yz/(4*sqrt(pi))
+		// dx += (float)dL_dy(12) * (0);                               // 0
+		// dy += (float)dL_dy(12) * (0);                               // 0
+		dz += (float)dL_dy(12) * (5.597644988851731*z2 - 1.1195289977703462);                          // 3*sqrt(7)*(5*z2 - 1)/(4*sqrt(pi))
+		dx += (float)dL_dy(13) * (0.45704579946446572 - 2.2852289973223288*z2);                                // sqrt(42)*(1 - 5*z2)/(8*sqrt(pi))
+		// dy += (float)dL_dy(13) * (0);                               // 0
+		dz += (float)dL_dy(13) * (-4.5704579946446566*xz);                             // -5*sqrt(42)*xz/(4*sqrt(pi))
+		dx += (float)dL_dy(14) * (2.8906114426405538*xz);                              // sqrt(105)*xz/(2*sqrt(pi))
+		dy += (float)dL_dy(14) * (-2.8906114426405538*yz);                             // -sqrt(105)*yz/(2*sqrt(pi))
+		dz += (float)dL_dy(14) * (1.4453057213202769*x2 - 1.4453057213202769*y2);                              // sqrt(105)*(x2 - y2)/(4*sqrt(pi))
+		dx += (float)dL_dy(15) * (-1.7701307697799304*x2 + 1.7701307697799304*y2);                             // 3*sqrt(70)*(-x2 + y2)/(8*sqrt(pi))
+		dy += (float)dL_dy(15) * (3.5402615395598609*xy);                              // 3*sqrt(70)*xy/(4*sqrt(pi))
+		// dz += (float)dL_dy(15) * (0);                               // 0
 		if (degree <= 4) { return; }
-		dx += (float)*grad(16) * (2.5033429417967046*y*(3.0*x2 - y2));                         // 3*sqrt(35)*y*(3*x2 - y2)/(4*sqrt(pi))
-		dy += (float)*grad(16) * (2.5033429417967046*x*(x2 - 3.0*y2));                         // 3*sqrt(35)*x*(x2 - 3*y2)/(4*sqrt(pi))
-		// dz += (float)*grad(16) * (0);                               // 0
-		dx += (float)*grad(17) * (-10.620784618679583*xy*z);                           // -9*sqrt(70)*xy*z/(4*sqrt(pi))
-		dy += (float)*grad(17) * (5.3103923093397913*z*(-x2 + y2));                            // 9*sqrt(70)*z*(-x2 + y2)/(8*sqrt(pi))
-		dz += (float)*grad(17) * (1.7701307697799304*y*(-3.0*x2 + y2));                                // 3*sqrt(70)*y*(-3*x2 + y2)/(8*sqrt(pi))
-		dx += (float)*grad(18) * (0.94617469575756008*y*(7.0*z2 - 1.0));                               // 3*sqrt(5)*y*(7*z2 - 1)/(4*sqrt(pi))
-		dy += (float)*grad(18) * (0.94617469575756008*x*(7.0*z2 - 1.0));                               // 3*sqrt(5)*x*(7*z2 - 1)/(4*sqrt(pi))
-		dz += (float)*grad(18) * (13.246445740605839*xy*z);                            // 21*sqrt(5)*xy*z/(2*sqrt(pi))
-		// dx += (float)*grad(19) * (0);                               // 0
-		dy += (float)*grad(19) * (0.66904654355728921*z*(3.0 - 7.0*z2));                               // 3*sqrt(10)*z*(3 - 7*z2)/(8*sqrt(pi))
-		dz += (float)*grad(19) * (2.0071396306718676*y*(1.0 - 7.0*z2));                                // 9*sqrt(10)*y*(1 - 7*z2)/(8*sqrt(pi))
-		// dx += (float)*grad(20) * (0);                               // 0
-		// dy += (float)*grad(20) * (0);                               // 0
-		dz += (float)*grad(20) * (14.809976568128603*pow(z, 3) - 6.3471328149122579*z);                                // (105*z**3 - 45*z)/(4*sqrt(pi))
-		dx += (float)*grad(21) * (0.66904654355728921*z*(3.0 - 7.0*z2));                               // 3*sqrt(10)*z*(3 - 7*z2)/(8*sqrt(pi))
-		// dy += (float)*grad(21) * (0);                               // 0
-		dz += (float)*grad(21) * (2.0071396306718676*x*(1.0 - 7.0*z2));                                // 9*sqrt(10)*x*(1 - 7*z2)/(8*sqrt(pi))
-		dx += (float)*grad(22) * (0.94617469575756008*x*(7.0*z2 - 1.0));                               // 3*sqrt(5)*x*(7*z2 - 1)/(4*sqrt(pi))
-		dy += (float)*grad(22) * (0.94617469575756008*y*(1.0 - 7.0*z2));                               // 3*sqrt(5)*y*(1 - 7*z2)/(4*sqrt(pi))
-		dz += (float)*grad(22) * (6.6232228703029197*z*(x2 - y2));                             // 21*sqrt(5)*z*(x2 - y2)/(4*sqrt(pi))
-		dx += (float)*grad(23) * (5.3103923093397913*z*(-x2 + y2));                            // 9*sqrt(70)*z*(-x2 + y2)/(8*sqrt(pi))
-		dy += (float)*grad(23) * (10.620784618679583*xy*z);                            // 9*sqrt(70)*xy*z/(4*sqrt(pi))
-		dz += (float)*grad(23) * (1.7701307697799304*x*(-x2 + 3.0*y2));                                // 3*sqrt(70)*x*(-x2 + 3*y2)/(8*sqrt(pi))
-		dx += (float)*grad(24) * (2.5033429417967046*x*(x2 - 3.0*y2));                         // 3*sqrt(35)*x*(x2 - 3*y2)/(4*sqrt(pi))
-		dy += (float)*grad(24) * (2.5033429417967046*y*(-3.0*x2 + y2));                                // 3*sqrt(35)*y*(-3*x2 + y2)/(4*sqrt(pi))
-		// dz += (float)*grad(24) * (0);                               // 0
+		dx += (float)dL_dy(16) * (2.5033429417967046*y*(3.0*x2 - y2));                         // 3*sqrt(35)*y*(3*x2 - y2)/(4*sqrt(pi))
+		dy += (float)dL_dy(16) * (2.5033429417967046*x*(x2 - 3.0*y2));                         // 3*sqrt(35)*x*(x2 - 3*y2)/(4*sqrt(pi))
+		// dz += (float)dL_dy(16) * (0);                               // 0
+		dx += (float)dL_dy(17) * (-10.620784618679583*xy*z);                           // -9*sqrt(70)*xy*z/(4*sqrt(pi))
+		dy += (float)dL_dy(17) * (5.3103923093397913*z*(-x2 + y2));                            // 9*sqrt(70)*z*(-x2 + y2)/(8*sqrt(pi))
+		dz += (float)dL_dy(17) * (1.7701307697799304*y*(-3.0*x2 + y2));                                // 3*sqrt(70)*y*(-3*x2 + y2)/(8*sqrt(pi))
+		dx += (float)dL_dy(18) * (0.94617469575756008*y*(7.0*z2 - 1.0));                               // 3*sqrt(5)*y*(7*z2 - 1)/(4*sqrt(pi))
+		dy += (float)dL_dy(18) * (0.94617469575756008*x*(7.0*z2 - 1.0));                               // 3*sqrt(5)*x*(7*z2 - 1)/(4*sqrt(pi))
+		dz += (float)dL_dy(18) * (13.246445740605839*xy*z);                            // 21*sqrt(5)*xy*z/(2*sqrt(pi))
+		// dx += (float)dL_dy(19) * (0);                               // 0
+		dy += (float)dL_dy(19) * (0.66904654355728921*z*(3.0 - 7.0*z2));                               // 3*sqrt(10)*z*(3 - 7*z2)/(8*sqrt(pi))
+		dz += (float)dL_dy(19) * (2.0071396306718676*y*(1.0 - 7.0*z2));                                // 9*sqrt(10)*y*(1 - 7*z2)/(8*sqrt(pi))
+		// dx += (float)dL_dy(20) * (0);                               // 0
+		// dy += (float)dL_dy(20) * (0);                               // 0
+		dz += (float)dL_dy(20) * (14.809976568128603*pow(z, 3) - 6.3471328149122579*z);                                // (105*z**3 - 45*z)/(4*sqrt(pi))
+		dx += (float)dL_dy(21) * (0.66904654355728921*z*(3.0 - 7.0*z2));                               // 3*sqrt(10)*z*(3 - 7*z2)/(8*sqrt(pi))
+		// dy += (float)dL_dy(21) * (0);                               // 0
+		dz += (float)dL_dy(21) * (2.0071396306718676*x*(1.0 - 7.0*z2));                                // 9*sqrt(10)*x*(1 - 7*z2)/(8*sqrt(pi))
+		dx += (float)dL_dy(22) * (0.94617469575756008*x*(7.0*z2 - 1.0));                               // 3*sqrt(5)*x*(7*z2 - 1)/(4*sqrt(pi))
+		dy += (float)dL_dy(22) * (0.94617469575756008*y*(1.0 - 7.0*z2));                               // 3*sqrt(5)*y*(1 - 7*z2)/(4*sqrt(pi))
+		dz += (float)dL_dy(22) * (6.6232228703029197*z*(x2 - y2));                             // 21*sqrt(5)*z*(x2 - y2)/(4*sqrt(pi))
+		dx += (float)dL_dy(23) * (5.3103923093397913*z*(-x2 + y2));                            // 9*sqrt(70)*z*(-x2 + y2)/(8*sqrt(pi))
+		dy += (float)dL_dy(23) * (10.620784618679583*xy*z);                            // 9*sqrt(70)*xy*z/(4*sqrt(pi))
+		dz += (float)dL_dy(23) * (1.7701307697799304*x*(-x2 + 3.0*y2));                                // 3*sqrt(70)*x*(-x2 + 3*y2)/(8*sqrt(pi))
+		dx += (float)dL_dy(24) * (2.5033429417967046*x*(x2 - 3.0*y2));                         // 3*sqrt(35)*x*(x2 - 3*y2)/(4*sqrt(pi))
+		dy += (float)dL_dy(24) * (2.5033429417967046*y*(-3.0*x2 + y2));                                // 3*sqrt(35)*y*(-3*x2 + y2)/(4*sqrt(pi))
+		// dz += (float)dL_dy(24) * (0);                               // 0
 		if (degree <= 5) { return; }
-		dx += (float)*grad(25) * (13.127641136803401*xy*(-x2 + y2));                           // 15*sqrt(154)*xy*(-x2 + y2)/(8*sqrt(pi))
-		dy += (float)*grad(25) * (19.6914617052051*x2*y2 - 3.2819102842008503*x4 - 3.2819102842008503*y4);                             // 15*sqrt(154)*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
-		// dz += (float)*grad(25) * (0);                               // 0
-		dx += (float)*grad(26) * (8.3026492595241645*yz*(3.0*x2 - y2));                                // 3*sqrt(385)*yz*(3*x2 - y2)/(4*sqrt(pi))
-		dy += (float)*grad(26) * (8.3026492595241645*xz*(x2 - 3.0*y2));                                // 3*sqrt(385)*xz*(x2 - 3*y2)/(4*sqrt(pi))
-		dz += (float)*grad(26) * (8.3026492595241645*xy*(x2 - y2));                            // 3*sqrt(385)*xy*(x2 - y2)/(4*sqrt(pi))
-		dx += (float)*grad(27) * (2.9354297966115022*xy*(1.0 - 9.0*z2));                               // 3*sqrt(770)*xy*(1 - 9*z2)/(16*sqrt(pi))
-		dy += (float)*grad(27) * (-1.4677148983057511*(x2 - y2)*(9.0*z2 - 1.0));                               // -3*sqrt(770)*(x2 - y2)*(9*z2 - 1)/(32*sqrt(pi))
-		dz += (float)*grad(27) * (8.8062893898345074*yz*(-3.0*x2 + y2));                               // 9*sqrt(770)*yz*(-3*x2 + y2)/(16*sqrt(pi))
-		dx += (float)*grad(28) * (4.7935367849733241*yz*(3.0*z2 - 1.0));                               // sqrt(1155)*yz*(3*z2 - 1)/(4*sqrt(pi))
-		dy += (float)*grad(28) * (4.7935367849733241*xz*(3.0*z2 - 1.0));                               // sqrt(1155)*xz*(3*z2 - 1)/(4*sqrt(pi))
-		dz += (float)*grad(28) * (4.7935367849733241*xy*(9.0*z2 - 1.0));                               // sqrt(1155)*xy*(9*z2 - 1)/(4*sqrt(pi))
-		// dx += (float)*grad(29) * (0);                               // 0
-		dy += (float)*grad(29) * (6.3412531167397574*z2 - 9.5118796751096362*z4 - 0.45294665119569694);                                // sqrt(165)*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
-		dz += (float)*grad(29) * (12.682506233479513*yz*(1.0 - 3.0*z2));                               // 7*sqrt(165)*yz*(1 - 3*z2)/(4*sqrt(pi))
-		// dx += (float)*grad(30) * (0);                               // 0
-		// dy += (float)*grad(30) * (0);                               // 0
-		dz += (float)*grad(30) * (-24.559567715218954*z2 + 36.839351572828434*z4 + 1.754254836801354);                         // 15*sqrt(11)*(-14*z2 + 21*z4 + 1)/(16*sqrt(pi))
-		dx += (float)*grad(31) * (6.3412531167397574*z2 - 9.5118796751096362*z4 - 0.45294665119569694);                                // sqrt(165)*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
-		// dy += (float)*grad(31) * (0);                               // 0
-		dz += (float)*grad(31) * (12.682506233479513*xz*(1.0 - 3.0*z2));                               // 7*sqrt(165)*xz*(1 - 3*z2)/(4*sqrt(pi))
-		dx += (float)*grad(32) * (4.7935367849733241*xz*(3.0*z2 - 1.0));                               // sqrt(1155)*xz*(3*z2 - 1)/(4*sqrt(pi))
-		dy += (float)*grad(32) * (4.7935367849733241*yz*(1.0 - 3.0*z2));                               // sqrt(1155)*yz*(1 - 3*z2)/(4*sqrt(pi))
-		dz += (float)*grad(32) * (2.3967683924866621*(x2 - y2)*(9.0*z2 - 1.0));                                // sqrt(1155)*(x2 - y2)*(9*z2 - 1)/(8*sqrt(pi))
-		dx += (float)*grad(33) * (-13.209434084751759*x2*z2 + 1.4677148983057511*x2 + 13.209434084751759*y2*z2 - 1.4677148983057511*y2);                               // 3*sqrt(770)*(-9*x2*z2 + x2 + 9*y2*z2 - y2)/(32*sqrt(pi))
-		dy += (float)*grad(33) * (2.9354297966115022*xy*(9.0*z2 - 1.0));                               // 3*sqrt(770)*xy*(9*z2 - 1)/(16*sqrt(pi))
-		dz += (float)*grad(33) * (8.8062893898345074*xz*(-x2 + 3.0*y2));                               // 9*sqrt(770)*xz*(-x2 + 3*y2)/(16*sqrt(pi))
-		dx += (float)*grad(34) * (8.3026492595241645*xz*(x2 - 3.0*y2));                                // 3*sqrt(385)*xz*(x2 - 3*y2)/(4*sqrt(pi))
-		dy += (float)*grad(34) * (8.3026492595241645*yz*(-3.0*x2 + y2));                               // 3*sqrt(385)*yz*(-3*x2 + y2)/(4*sqrt(pi))
-		dz += (float)*grad(34) * (-12.453973889286246*x2*y2 + 2.0756623148810411*x4 + 2.0756623148810411*y4);                          // 3*sqrt(385)*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
-		dx += (float)*grad(35) * (19.6914617052051*x2*y2 - 3.2819102842008503*x4 - 3.2819102842008503*y4);                             // 15*sqrt(154)*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
-		dy += (float)*grad(35) * (13.127641136803401*xy*(x2 - y2));                            // 15*sqrt(154)*xy*(x2 - y2)/(8*sqrt(pi))
-		// dz += (float)*grad(35) * (0);                               // 0
+		dx += (float)dL_dy(25) * (13.127641136803401*xy*(-x2 + y2));                           // 15*sqrt(154)*xy*(-x2 + y2)/(8*sqrt(pi))
+		dy += (float)dL_dy(25) * (19.6914617052051*x2*y2 - 3.2819102842008503*x4 - 3.2819102842008503*y4);                             // 15*sqrt(154)*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
+		// dz += (float)dL_dy(25) * (0);                               // 0
+		dx += (float)dL_dy(26) * (8.3026492595241645*yz*(3.0*x2 - y2));                                // 3*sqrt(385)*yz*(3*x2 - y2)/(4*sqrt(pi))
+		dy += (float)dL_dy(26) * (8.3026492595241645*xz*(x2 - 3.0*y2));                                // 3*sqrt(385)*xz*(x2 - 3*y2)/(4*sqrt(pi))
+		dz += (float)dL_dy(26) * (8.3026492595241645*xy*(x2 - y2));                            // 3*sqrt(385)*xy*(x2 - y2)/(4*sqrt(pi))
+		dx += (float)dL_dy(27) * (2.9354297966115022*xy*(1.0 - 9.0*z2));                               // 3*sqrt(770)*xy*(1 - 9*z2)/(16*sqrt(pi))
+		dy += (float)dL_dy(27) * (-1.4677148983057511*(x2 - y2)*(9.0*z2 - 1.0));                               // -3*sqrt(770)*(x2 - y2)*(9*z2 - 1)/(32*sqrt(pi))
+		dz += (float)dL_dy(27) * (8.8062893898345074*yz*(-3.0*x2 + y2));                               // 9*sqrt(770)*yz*(-3*x2 + y2)/(16*sqrt(pi))
+		dx += (float)dL_dy(28) * (4.7935367849733241*yz*(3.0*z2 - 1.0));                               // sqrt(1155)*yz*(3*z2 - 1)/(4*sqrt(pi))
+		dy += (float)dL_dy(28) * (4.7935367849733241*xz*(3.0*z2 - 1.0));                               // sqrt(1155)*xz*(3*z2 - 1)/(4*sqrt(pi))
+		dz += (float)dL_dy(28) * (4.7935367849733241*xy*(9.0*z2 - 1.0));                               // sqrt(1155)*xy*(9*z2 - 1)/(4*sqrt(pi))
+		// dx += (float)dL_dy(29) * (0);                               // 0
+		dy += (float)dL_dy(29) * (6.3412531167397574*z2 - 9.5118796751096362*z4 - 0.45294665119569694);                                // sqrt(165)*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
+		dz += (float)dL_dy(29) * (12.682506233479513*yz*(1.0 - 3.0*z2));                               // 7*sqrt(165)*yz*(1 - 3*z2)/(4*sqrt(pi))
+		// dx += (float)dL_dy(30) * (0);                               // 0
+		// dy += (float)dL_dy(30) * (0);                               // 0
+		dz += (float)dL_dy(30) * (-24.559567715218954*z2 + 36.839351572828434*z4 + 1.754254836801354);                         // 15*sqrt(11)*(-14*z2 + 21*z4 + 1)/(16*sqrt(pi))
+		dx += (float)dL_dy(31) * (6.3412531167397574*z2 - 9.5118796751096362*z4 - 0.45294665119569694);                                // sqrt(165)*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
+		// dy += (float)dL_dy(31) * (0);                               // 0
+		dz += (float)dL_dy(31) * (12.682506233479513*xz*(1.0 - 3.0*z2));                               // 7*sqrt(165)*xz*(1 - 3*z2)/(4*sqrt(pi))
+		dx += (float)dL_dy(32) * (4.7935367849733241*xz*(3.0*z2 - 1.0));                               // sqrt(1155)*xz*(3*z2 - 1)/(4*sqrt(pi))
+		dy += (float)dL_dy(32) * (4.7935367849733241*yz*(1.0 - 3.0*z2));                               // sqrt(1155)*yz*(1 - 3*z2)/(4*sqrt(pi))
+		dz += (float)dL_dy(32) * (2.3967683924866621*(x2 - y2)*(9.0*z2 - 1.0));                                // sqrt(1155)*(x2 - y2)*(9*z2 - 1)/(8*sqrt(pi))
+		dx += (float)dL_dy(33) * (-13.209434084751759*x2*z2 + 1.4677148983057511*x2 + 13.209434084751759*y2*z2 - 1.4677148983057511*y2);                               // 3*sqrt(770)*(-9*x2*z2 + x2 + 9*y2*z2 - y2)/(32*sqrt(pi))
+		dy += (float)dL_dy(33) * (2.9354297966115022*xy*(9.0*z2 - 1.0));                               // 3*sqrt(770)*xy*(9*z2 - 1)/(16*sqrt(pi))
+		dz += (float)dL_dy(33) * (8.8062893898345074*xz*(-x2 + 3.0*y2));                               // 9*sqrt(770)*xz*(-x2 + 3*y2)/(16*sqrt(pi))
+		dx += (float)dL_dy(34) * (8.3026492595241645*xz*(x2 - 3.0*y2));                                // 3*sqrt(385)*xz*(x2 - 3*y2)/(4*sqrt(pi))
+		dy += (float)dL_dy(34) * (8.3026492595241645*yz*(-3.0*x2 + y2));                               // 3*sqrt(385)*yz*(-3*x2 + y2)/(4*sqrt(pi))
+		dz += (float)dL_dy(34) * (-12.453973889286246*x2*y2 + 2.0756623148810411*x4 + 2.0756623148810411*y4);                          // 3*sqrt(385)*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
+		dx += (float)dL_dy(35) * (19.6914617052051*x2*y2 - 3.2819102842008503*x4 - 3.2819102842008503*y4);                             // 15*sqrt(154)*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
+		dy += (float)dL_dy(35) * (13.127641136803401*xy*(x2 - y2));                            // 15*sqrt(154)*xy*(x2 - y2)/(8*sqrt(pi))
+		// dz += (float)dL_dy(35) * (0);                               // 0
 		if (degree <= 6) { return; }
-		dx += (float)*grad(36) * (4.0991046311514854*y*(-10.0*x2*y2 + 5.0*x4 + y4));                           // 3*sqrt(6006)*y*(-10*x2*y2 + 5*x4 + y4)/(32*sqrt(pi))
-		dy += (float)*grad(36) * (4.0991046311514854*x*(-10.0*x2*y2 + x4 + 5.0*y4));                           // 3*sqrt(6006)*x*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
-		// dz += (float)*grad(36) * (0);                               // 0
-		dx += (float)*grad(37) * (47.332383244635047*xy*z*(-x2 + y2));                         // 15*sqrt(2002)*xy*z*(-x2 + y2)/(8*sqrt(pi))
-		dy += (float)*grad(37) * (11.833095811158762*z*(6.0*x2*y2 - x4 - y4));                         // 15*sqrt(2002)*z*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
-		dz += (float)*grad(37) * (2.3666191622317521*y*(10.0*x2*y2 - 5.0*x4 - y4));                            // 3*sqrt(2002)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		dx += (float)*grad(38) * (2.0182596029148963*y*(3.0*x2 - y2)*(11.0*z2 - 1.0));                         // 3*sqrt(91)*y*(3*x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
-		dy += (float)*grad(38) * (2.0182596029148963*x*(x2 - 3.0*y2)*(11.0*z2 - 1.0));                         // 3*sqrt(91)*x*(x2 - 3*y2)*(11*z2 - 1)/(8*sqrt(pi))
-		dz += (float)*grad(38) * (44.401711264127719*xy*z*(x2 - y2));                          // 33*sqrt(91)*xy*z*(x2 - y2)/(4*sqrt(pi))
-		dx += (float)*grad(39) * (5.5272315570895412*xy*z*(3.0 - 11.0*z2));                            // 3*sqrt(2730)*xy*z*(3 - 11*z2)/(16*sqrt(pi))
-		dy += (float)*grad(39) * (-2.7636157785447706*z*(x2 - y2)*(11.0*z2 - 3.0));                            // -3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
-		dz += (float)*grad(39) * (-2.7636157785447706*y*(3.0*x2 - y2)*(11.0*z2 - 1.0));                                // -3*sqrt(2730)*y*(3*x2 - y2)*(11*z2 - 1)/(32*sqrt(pi))
-		dx += (float)*grad(40) * (0.92120525951492349*y*(-18.0*z2 + 33.0*z4 + 1.0));                           // sqrt(2730)*y*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
-		dy += (float)*grad(40) * (0.92120525951492349*x*(-18.0*z2 + 33.0*z4 + 1.0));                           // sqrt(2730)*x*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
-		dz += (float)*grad(40) * (11.054463114179082*xy*z*(11.0*z2 - 3.0));                            // 3*sqrt(2730)*xy*z*(11*z2 - 3)/(8*sqrt(pi))
-		// dx += (float)*grad(41) * (0);                               // 0
-		dy += (float)*grad(41) * (0.58262136251873131*z*(30.0*z2 - 33.0*z4 - 5.0));                            // sqrt(273)*z*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
-		dz += (float)*grad(41) * (2.9131068125936568*y*(18.0*z2 - 33.0*z4 - 1.0));                             // 5*sqrt(273)*y*(18*z2 - 33*z4 - 1)/(16*sqrt(pi))
-		// dx += (float)*grad(42) * (0);                               // 0
-		// dy += (float)*grad(42) * (0);                               // 0
-		dz += (float)*grad(42) * (2.6699064952403937*z*(-30.0*z2 + 33.0*z4 + 5.0));                            // 21*sqrt(13)*z*(-30*z2 + 33*z4 + 5)/(16*sqrt(pi))
-		dx += (float)*grad(43) * (0.58262136251873131*z*(30.0*z2 - 33.0*z4 - 5.0));                            // sqrt(273)*z*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
-		// dy += (float)*grad(43) * (0);                               // 0
-		dz += (float)*grad(43) * (2.9131068125936568*x*(18.0*z2 - 33.0*z4 - 1.0));                             // 5*sqrt(273)*x*(18*z2 - 33*z4 - 1)/(16*sqrt(pi))
-		dx += (float)*grad(44) * (0.92120525951492349*x*(-18.0*z2 + 33.0*z4 + 1.0));                           // sqrt(2730)*x*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
-		dy += (float)*grad(44) * (0.92120525951492349*y*(18.0*z2 - 33.0*z4 - 1.0));                            // sqrt(2730)*y*(18*z2 - 33*z4 - 1)/(32*sqrt(pi))
-		dz += (float)*grad(44) * (5.5272315570895412*z*(x2 - y2)*(11.0*z2 - 3.0));                             // 3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(16*sqrt(pi))
-		dx += (float)*grad(45) * (-2.7636157785447706*z*(x2 - y2)*(11.0*z2 - 3.0));                            // -3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
-		dy += (float)*grad(45) * (5.5272315570895412*xy*z*(11.0*z2 - 3.0));                            // 3*sqrt(2730)*xy*z*(11*z2 - 3)/(16*sqrt(pi))
-		dz += (float)*grad(45) * (-2.7636157785447706*x*(x2 - 3.0*y2)*(11.0*z2 - 1.0));                                // -3*sqrt(2730)*x*(x2 - 3*y2)*(11*z2 - 1)/(32*sqrt(pi))
-		dx += (float)*grad(46) * (2.0182596029148963*x*(x2 - 3.0*y2)*(11.0*z2 - 1.0));                         // 3*sqrt(91)*x*(x2 - 3*y2)*(11*z2 - 1)/(8*sqrt(pi))
-		dy += (float)*grad(46) * (-2.0182596029148963*y*(3.0*x2 - y2)*(11.0*z2 - 1.0));                                // -3*sqrt(91)*y*(3*x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
-		dz += (float)*grad(46) * (11.10042781603193*z*(-6.0*x2*y2 + x4 + y4));                         // 33*sqrt(91)*z*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
-		dx += (float)*grad(47) * (11.833095811158762*z*(6.0*x2*y2 - x4 - y4));                         // 15*sqrt(2002)*z*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
-		dy += (float)*grad(47) * (47.332383244635047*xy*z*(x2 - y2));                          // 15*sqrt(2002)*xy*z*(x2 - y2)/(8*sqrt(pi))
-		dz += (float)*grad(47) * (2.3666191622317521*x*(10.0*x2*y2 - x4 - 5.0*y4));                            // 3*sqrt(2002)*x*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
-		dx += (float)*grad(48) * (4.0991046311514854*x*(-10.0*x2*y2 + x4 + 5.0*y4));                           // 3*sqrt(6006)*x*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
-		dy += (float)*grad(48) * (4.0991046311514854*y*(10.0*x2*y2 - 5.0*x4 - y4));                            // 3*sqrt(6006)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		// dz += (float)*grad(48) * (0);                               // 0
+		dx += (float)dL_dy(36) * (4.0991046311514854*y*(-10.0*x2*y2 + 5.0*x4 + y4));                           // 3*sqrt(6006)*y*(-10*x2*y2 + 5*x4 + y4)/(32*sqrt(pi))
+		dy += (float)dL_dy(36) * (4.0991046311514854*x*(-10.0*x2*y2 + x4 + 5.0*y4));                           // 3*sqrt(6006)*x*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
+		// dz += (float)dL_dy(36) * (0);                               // 0
+		dx += (float)dL_dy(37) * (47.332383244635047*xy*z*(-x2 + y2));                         // 15*sqrt(2002)*xy*z*(-x2 + y2)/(8*sqrt(pi))
+		dy += (float)dL_dy(37) * (11.833095811158762*z*(6.0*x2*y2 - x4 - y4));                         // 15*sqrt(2002)*z*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
+		dz += (float)dL_dy(37) * (2.3666191622317521*y*(10.0*x2*y2 - 5.0*x4 - y4));                            // 3*sqrt(2002)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		dx += (float)dL_dy(38) * (2.0182596029148963*y*(3.0*x2 - y2)*(11.0*z2 - 1.0));                         // 3*sqrt(91)*y*(3*x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
+		dy += (float)dL_dy(38) * (2.0182596029148963*x*(x2 - 3.0*y2)*(11.0*z2 - 1.0));                         // 3*sqrt(91)*x*(x2 - 3*y2)*(11*z2 - 1)/(8*sqrt(pi))
+		dz += (float)dL_dy(38) * (44.401711264127719*xy*z*(x2 - y2));                          // 33*sqrt(91)*xy*z*(x2 - y2)/(4*sqrt(pi))
+		dx += (float)dL_dy(39) * (5.5272315570895412*xy*z*(3.0 - 11.0*z2));                            // 3*sqrt(2730)*xy*z*(3 - 11*z2)/(16*sqrt(pi))
+		dy += (float)dL_dy(39) * (-2.7636157785447706*z*(x2 - y2)*(11.0*z2 - 3.0));                            // -3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
+		dz += (float)dL_dy(39) * (-2.7636157785447706*y*(3.0*x2 - y2)*(11.0*z2 - 1.0));                                // -3*sqrt(2730)*y*(3*x2 - y2)*(11*z2 - 1)/(32*sqrt(pi))
+		dx += (float)dL_dy(40) * (0.92120525951492349*y*(-18.0*z2 + 33.0*z4 + 1.0));                           // sqrt(2730)*y*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
+		dy += (float)dL_dy(40) * (0.92120525951492349*x*(-18.0*z2 + 33.0*z4 + 1.0));                           // sqrt(2730)*x*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
+		dz += (float)dL_dy(40) * (11.054463114179082*xy*z*(11.0*z2 - 3.0));                            // 3*sqrt(2730)*xy*z*(11*z2 - 3)/(8*sqrt(pi))
+		// dx += (float)dL_dy(41) * (0);                               // 0
+		dy += (float)dL_dy(41) * (0.58262136251873131*z*(30.0*z2 - 33.0*z4 - 5.0));                            // sqrt(273)*z*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
+		dz += (float)dL_dy(41) * (2.9131068125936568*y*(18.0*z2 - 33.0*z4 - 1.0));                             // 5*sqrt(273)*y*(18*z2 - 33*z4 - 1)/(16*sqrt(pi))
+		// dx += (float)dL_dy(42) * (0);                               // 0
+		// dy += (float)dL_dy(42) * (0);                               // 0
+		dz += (float)dL_dy(42) * (2.6699064952403937*z*(-30.0*z2 + 33.0*z4 + 5.0));                            // 21*sqrt(13)*z*(-30*z2 + 33*z4 + 5)/(16*sqrt(pi))
+		dx += (float)dL_dy(43) * (0.58262136251873131*z*(30.0*z2 - 33.0*z4 - 5.0));                            // sqrt(273)*z*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
+		// dy += (float)dL_dy(43) * (0);                               // 0
+		dz += (float)dL_dy(43) * (2.9131068125936568*x*(18.0*z2 - 33.0*z4 - 1.0));                             // 5*sqrt(273)*x*(18*z2 - 33*z4 - 1)/(16*sqrt(pi))
+		dx += (float)dL_dy(44) * (0.92120525951492349*x*(-18.0*z2 + 33.0*z4 + 1.0));                           // sqrt(2730)*x*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
+		dy += (float)dL_dy(44) * (0.92120525951492349*y*(18.0*z2 - 33.0*z4 - 1.0));                            // sqrt(2730)*y*(18*z2 - 33*z4 - 1)/(32*sqrt(pi))
+		dz += (float)dL_dy(44) * (5.5272315570895412*z*(x2 - y2)*(11.0*z2 - 3.0));                             // 3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(16*sqrt(pi))
+		dx += (float)dL_dy(45) * (-2.7636157785447706*z*(x2 - y2)*(11.0*z2 - 3.0));                            // -3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
+		dy += (float)dL_dy(45) * (5.5272315570895412*xy*z*(11.0*z2 - 3.0));                            // 3*sqrt(2730)*xy*z*(11*z2 - 3)/(16*sqrt(pi))
+		dz += (float)dL_dy(45) * (-2.7636157785447706*x*(x2 - 3.0*y2)*(11.0*z2 - 1.0));                                // -3*sqrt(2730)*x*(x2 - 3*y2)*(11*z2 - 1)/(32*sqrt(pi))
+		dx += (float)dL_dy(46) * (2.0182596029148963*x*(x2 - 3.0*y2)*(11.0*z2 - 1.0));                         // 3*sqrt(91)*x*(x2 - 3*y2)*(11*z2 - 1)/(8*sqrt(pi))
+		dy += (float)dL_dy(46) * (-2.0182596029148963*y*(3.0*x2 - y2)*(11.0*z2 - 1.0));                                // -3*sqrt(91)*y*(3*x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
+		dz += (float)dL_dy(46) * (11.10042781603193*z*(-6.0*x2*y2 + x4 + y4));                         // 33*sqrt(91)*z*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
+		dx += (float)dL_dy(47) * (11.833095811158762*z*(6.0*x2*y2 - x4 - y4));                         // 15*sqrt(2002)*z*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
+		dy += (float)dL_dy(47) * (47.332383244635047*xy*z*(x2 - y2));                          // 15*sqrt(2002)*xy*z*(x2 - y2)/(8*sqrt(pi))
+		dz += (float)dL_dy(47) * (2.3666191622317521*x*(10.0*x2*y2 - x4 - 5.0*y4));                            // 3*sqrt(2002)*x*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
+		dx += (float)dL_dy(48) * (4.0991046311514854*x*(-10.0*x2*y2 + x4 + 5.0*y4));                           // 3*sqrt(6006)*x*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
+		dy += (float)dL_dy(48) * (4.0991046311514854*y*(10.0*x2*y2 - 5.0*x4 - y4));                            // 3*sqrt(6006)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		// dz += (float)dL_dy(48) * (0);                               // 0
 		if (degree <= 7) { return; }
-		dx += (float)*grad(49) * (9.9002782553443485*xy*(10.0*x2*y2 - 3.0*x4 - 3.0*y4));                               // 21*sqrt(715)*xy*(10*x2*y2 - 3*x4 - 3*y4)/(32*sqrt(pi))
-		dy += (float)*grad(49) * (-74.252086915082614*x2*y4 + 74.252086915082614*x4*y2 - 4.9501391276721742*x6 + 4.9501391276721742*y6);                               // 21*sqrt(715)*(-15*x2*y4 + 15*x4*y2 - x6 + y6)/(64*sqrt(pi))
-		// dz += (float)*grad(49) * (0);                               // 0
-		dx += (float)*grad(50) * (15.875763970811402*yz*(-10.0*x2*y2 + 5.0*x4 + y4));                          // 9*sqrt(10010)*yz*(-10*x2*y2 + 5*x4 + y4)/(32*sqrt(pi))
-		dy += (float)*grad(50) * (15.875763970811402*xz*(-10.0*x2*y2 + x4 + 5.0*y4));                          // 9*sqrt(10010)*xz*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
-		dz += (float)*grad(50) * (5.2919213236038001*xy*(-10.0*x2*y2 + 3.0*x4 + 3.0*y4));                              // 3*sqrt(10010)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
-		dx += (float)*grad(51) * (-10.378311574405206*xy*(x2 - y2)*(13.0*z2 - 1.0));                           // -15*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(16*sqrt(pi))
-		dy += (float)*grad(51) * (0.51891557872026028*(13.0*z2 - 1.0)*(10.0*x2*y2 - 5.0*x4 + 4.0*y2*(5.0*x2 - y2) - y4));                              // 3*sqrt(385)*(13*z2 - 1)*(10*x2*y2 - 5*x4 + 4*y2*(5*x2 - y2) - y4)/(64*sqrt(pi))
-		dz += (float)*grad(51) * (13.491805046726766*yz*(10.0*x2*y2 - 5.0*x4 - y4));                           // 39*sqrt(385)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		dx += (float)*grad(52) * (4.1513246297620823*yz*(3.0*x2 - y2)*(13.0*z2 - 3.0));                                // 3*sqrt(385)*yz*(3*x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
-		dy += (float)*grad(52) * (4.1513246297620823*xz*(x2 - 3.0*y2)*(13.0*z2 - 3.0));                                // 3*sqrt(385)*xz*(x2 - 3*y2)*(13*z2 - 3)/(8*sqrt(pi))
-		dz += (float)*grad(52) * (12.453973889286248*xy*(x2 - y2)*(13.0*z2 - 1.0));                            // 9*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(8*sqrt(pi))
-		dx += (float)*grad(53) * (0.93875360317376422*xy*(66.0*z2 - 143.0*z4 - 3.0));                          // 9*sqrt(35)*xy*(66*z2 - 143*z4 - 3)/(32*sqrt(pi))
-		dy += (float)*grad(53) * (-0.46937680158688211*(x2 - y2)*(13.0*z2*(11.0*z2 - 3.0) - 27.0*z2 + 3.0));                           // -9*sqrt(35)*(x2 - y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
-		dz += (float)*grad(53) * (-6.8841930899409371*yz*(3.0*x2 - y2)*(13.0*z2 - 3.0));                               // -33*sqrt(35)*yz*(3*x2 - y2)*(13*z2 - 3)/(16*sqrt(pi))
-		dx += (float)*grad(54) * (0.44253269244498261*yz*(-110.0*z2 + 143.0*z4 + 15.0));                               // 3*sqrt(70)*yz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
-		dy += (float)*grad(54) * (0.44253269244498261*xz*(-110.0*z2 + 143.0*z4 + 15.0));                               // 3*sqrt(70)*xz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
-		dz += (float)*grad(54) * (2.2126634622249131*xy*(-66.0*z2 + 143.0*z4 + 3.0));                          // 15*sqrt(70)*xy*(-66*z2 + 143*z4 + 3)/(32*sqrt(pi))
-		// dx += (float)*grad(55) * (0);                               // 0
-		dy += (float)*grad(55) * (-12.194767023639836*z2 + 44.714145753346067*z4 - 38.752259652899923*z6 + 0.45165803791258652);                               // sqrt(105)*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
-		dz += (float)*grad(55) * (1.6259689364853116*yz*(110.0*z2 - 143.0*z4 - 15.0));                         // 9*sqrt(105)*yz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
-		// dx += (float)*grad(56) * (0);                               // 0
-		// dy += (float)*grad(56) * (0);                               // 0
-		dz += (float)*grad(56) * (64.528641681844675*z2 - 236.60501950009714*z4 + 205.05768356675085*z6 - 2.3899496919201733);                         // 7*sqrt(15)*(135*z2 - 495*z4 + 429*z6 - 5)/(32*sqrt(pi))
-		dx += (float)*grad(57) * (-12.194767023639836*z2 + 44.714145753346067*z4 - 38.752259652899923*z6 + 0.45165803791258652);                               // sqrt(105)*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
-		// dy += (float)*grad(57) * (0);                               // 0
-		dz += (float)*grad(57) * (1.6259689364853116*xz*(110.0*z2 - 143.0*z4 - 15.0));                         // 9*sqrt(105)*xz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
-		dx += (float)*grad(58) * (0.44253269244498261*xz*(-110.0*z2 + 143.0*z4 + 15.0));                               // 3*sqrt(70)*xz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
-		dy += (float)*grad(58) * (0.44253269244498261*yz*(110.0*z2 - 143.0*z4 - 15.0));                                // 3*sqrt(70)*yz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
-		dz += (float)*grad(58) * (0.07375544874083044*(x2 - y2)*(143.0*z2*(3.0*z2 - 1.0) + 132.0*z2*(13.0*z2 - 5.0) - 187.0*z2 + 45.0));                               // sqrt(70)*(x2 - y2)*(143*z2*(3*z2 - 1) + 132*z2*(13*z2 - 5) - 187*z2 + 45)/(64*sqrt(pi))
-		dx += (float)*grad(59) * (30.97886890473422*x2*z2 - 67.120882626924143*x2*z4 - 1.4081304047606462*x2 - 30.97886890473422*y2*z2 + 67.120882626924143*y2*z4 + 1.4081304047606462*y2);                            // 9*sqrt(35)*(66*x2*z2 - 143*x2*z4 - 3*x2 - 66*y2*z2 + 143*y2*z4 + 3*y2)/(64*sqrt(pi))
-		dy += (float)*grad(59) * (0.93875360317376422*xy*(-66.0*z2 + 143.0*z4 + 3.0));                         // 9*sqrt(35)*xy*(-66*z2 + 143*z4 + 3)/(32*sqrt(pi))
-		dz += (float)*grad(59) * (-6.8841930899409371*xz*(x2 - 3.0*y2)*(13.0*z2 - 3.0));                               // -33*sqrt(35)*xz*(x2 - 3*y2)*(13*z2 - 3)/(16*sqrt(pi))
-		dx += (float)*grad(60) * (4.1513246297620823*xz*(x2 - 3.0*y2)*(13.0*z2 - 3.0));                                // 3*sqrt(385)*xz*(x2 - 3*y2)*(13*z2 - 3)/(8*sqrt(pi))
-		dy += (float)*grad(60) * (-4.1513246297620823*yz*(3.0*x2 - y2)*(13.0*z2 - 3.0));                               // -3*sqrt(385)*yz*(3*x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
-		dz += (float)*grad(60) * (3.1134934723215619*(13.0*z2 - 1.0)*(-6.0*x2*y2 + x4 + y4));                          // 9*sqrt(385)*(13*z2 - 1)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
-		dx += (float)*grad(61) * (-0.51891557872026028*(13.0*z2 - 1.0)*(-10.0*x2*y2 + 4.0*x2*(x2 - 5.0*y2) + x4 + 5.0*y4));                            // -3*sqrt(385)*(13*z2 - 1)*(-10*x2*y2 + 4*x2*(x2 - 5*y2) + x4 + 5*y4)/(64*sqrt(pi))
-		dy += (float)*grad(61) * (10.378311574405206*xy*(x2 - y2)*(13.0*z2 - 1.0));                            // 15*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(16*sqrt(pi))
-		dz += (float)*grad(61) * (13.491805046726766*xz*(10.0*x2*y2 - x4 - 5.0*y4));                           // 39*sqrt(385)*xz*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
-		dx += (float)*grad(62) * (15.875763970811402*xz*(-10.0*x2*y2 + x4 + 5.0*y4));                          // 9*sqrt(10010)*xz*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
-		dy += (float)*grad(62) * (15.875763970811402*yz*(10.0*x2*y2 - 5.0*x4 - y4));                           // 9*sqrt(10010)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		dz += (float)*grad(62) * (39.6894099270285*x2*y4 - 39.6894099270285*x4*y2 + 2.6459606618019*x6 - 2.6459606618019*y6);                          // 3*sqrt(10010)*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
-		dx += (float)*grad(63) * (-74.252086915082614*x2*y4 + 74.252086915082614*x4*y2 - 4.9501391276721742*x6 + 4.9501391276721742*y6);                               // 21*sqrt(715)*(-15*x2*y4 + 15*x4*y2 - x6 + y6)/(64*sqrt(pi))
-		dy += (float)*grad(63) * (9.9002782553443485*xy*(-10.0*x2*y2 + 3.0*x4 + 3.0*y4));                              // 21*sqrt(715)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
-		// dz += (float)*grad(63) * (0);                               // 0
+		dx += (float)dL_dy(49) * (9.9002782553443485*xy*(10.0*x2*y2 - 3.0*x4 - 3.0*y4));                               // 21*sqrt(715)*xy*(10*x2*y2 - 3*x4 - 3*y4)/(32*sqrt(pi))
+		dy += (float)dL_dy(49) * (-74.252086915082614*x2*y4 + 74.252086915082614*x4*y2 - 4.9501391276721742*x6 + 4.9501391276721742*y6);                               // 21*sqrt(715)*(-15*x2*y4 + 15*x4*y2 - x6 + y6)/(64*sqrt(pi))
+		// dz += (float)dL_dy(49) * (0);                               // 0
+		dx += (float)dL_dy(50) * (15.875763970811402*yz*(-10.0*x2*y2 + 5.0*x4 + y4));                          // 9*sqrt(10010)*yz*(-10*x2*y2 + 5*x4 + y4)/(32*sqrt(pi))
+		dy += (float)dL_dy(50) * (15.875763970811402*xz*(-10.0*x2*y2 + x4 + 5.0*y4));                          // 9*sqrt(10010)*xz*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
+		dz += (float)dL_dy(50) * (5.2919213236038001*xy*(-10.0*x2*y2 + 3.0*x4 + 3.0*y4));                              // 3*sqrt(10010)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
+		dx += (float)dL_dy(51) * (-10.378311574405206*xy*(x2 - y2)*(13.0*z2 - 1.0));                           // -15*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(16*sqrt(pi))
+		dy += (float)dL_dy(51) * (0.51891557872026028*(13.0*z2 - 1.0)*(10.0*x2*y2 - 5.0*x4 + 4.0*y2*(5.0*x2 - y2) - y4));                              // 3*sqrt(385)*(13*z2 - 1)*(10*x2*y2 - 5*x4 + 4*y2*(5*x2 - y2) - y4)/(64*sqrt(pi))
+		dz += (float)dL_dy(51) * (13.491805046726766*yz*(10.0*x2*y2 - 5.0*x4 - y4));                           // 39*sqrt(385)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		dx += (float)dL_dy(52) * (4.1513246297620823*yz*(3.0*x2 - y2)*(13.0*z2 - 3.0));                                // 3*sqrt(385)*yz*(3*x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
+		dy += (float)dL_dy(52) * (4.1513246297620823*xz*(x2 - 3.0*y2)*(13.0*z2 - 3.0));                                // 3*sqrt(385)*xz*(x2 - 3*y2)*(13*z2 - 3)/(8*sqrt(pi))
+		dz += (float)dL_dy(52) * (12.453973889286248*xy*(x2 - y2)*(13.0*z2 - 1.0));                            // 9*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(8*sqrt(pi))
+		dx += (float)dL_dy(53) * (0.93875360317376422*xy*(66.0*z2 - 143.0*z4 - 3.0));                          // 9*sqrt(35)*xy*(66*z2 - 143*z4 - 3)/(32*sqrt(pi))
+		dy += (float)dL_dy(53) * (-0.46937680158688211*(x2 - y2)*(13.0*z2*(11.0*z2 - 3.0) - 27.0*z2 + 3.0));                           // -9*sqrt(35)*(x2 - y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
+		dz += (float)dL_dy(53) * (-6.8841930899409371*yz*(3.0*x2 - y2)*(13.0*z2 - 3.0));                               // -33*sqrt(35)*yz*(3*x2 - y2)*(13*z2 - 3)/(16*sqrt(pi))
+		dx += (float)dL_dy(54) * (0.44253269244498261*yz*(-110.0*z2 + 143.0*z4 + 15.0));                               // 3*sqrt(70)*yz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
+		dy += (float)dL_dy(54) * (0.44253269244498261*xz*(-110.0*z2 + 143.0*z4 + 15.0));                               // 3*sqrt(70)*xz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
+		dz += (float)dL_dy(54) * (2.2126634622249131*xy*(-66.0*z2 + 143.0*z4 + 3.0));                          // 15*sqrt(70)*xy*(-66*z2 + 143*z4 + 3)/(32*sqrt(pi))
+		// dx += (float)dL_dy(55) * (0);                               // 0
+		dy += (float)dL_dy(55) * (-12.194767023639836*z2 + 44.714145753346067*z4 - 38.752259652899923*z6 + 0.45165803791258652);                               // sqrt(105)*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
+		dz += (float)dL_dy(55) * (1.6259689364853116*yz*(110.0*z2 - 143.0*z4 - 15.0));                         // 9*sqrt(105)*yz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
+		// dx += (float)dL_dy(56) * (0);                               // 0
+		// dy += (float)dL_dy(56) * (0);                               // 0
+		dz += (float)dL_dy(56) * (64.528641681844675*z2 - 236.60501950009714*z4 + 205.05768356675085*z6 - 2.3899496919201733);                         // 7*sqrt(15)*(135*z2 - 495*z4 + 429*z6 - 5)/(32*sqrt(pi))
+		dx += (float)dL_dy(57) * (-12.194767023639836*z2 + 44.714145753346067*z4 - 38.752259652899923*z6 + 0.45165803791258652);                               // sqrt(105)*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
+		// dy += (float)dL_dy(57) * (0);                               // 0
+		dz += (float)dL_dy(57) * (1.6259689364853116*xz*(110.0*z2 - 143.0*z4 - 15.0));                         // 9*sqrt(105)*xz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
+		dx += (float)dL_dy(58) * (0.44253269244498261*xz*(-110.0*z2 + 143.0*z4 + 15.0));                               // 3*sqrt(70)*xz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
+		dy += (float)dL_dy(58) * (0.44253269244498261*yz*(110.0*z2 - 143.0*z4 - 15.0));                                // 3*sqrt(70)*yz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
+		dz += (float)dL_dy(58) * (0.07375544874083044*(x2 - y2)*(143.0*z2*(3.0*z2 - 1.0) + 132.0*z2*(13.0*z2 - 5.0) - 187.0*z2 + 45.0));                               // sqrt(70)*(x2 - y2)*(143*z2*(3*z2 - 1) + 132*z2*(13*z2 - 5) - 187*z2 + 45)/(64*sqrt(pi))
+		dx += (float)dL_dy(59) * (30.97886890473422*x2*z2 - 67.120882626924143*x2*z4 - 1.4081304047606462*x2 - 30.97886890473422*y2*z2 + 67.120882626924143*y2*z4 + 1.4081304047606462*y2);                            // 9*sqrt(35)*(66*x2*z2 - 143*x2*z4 - 3*x2 - 66*y2*z2 + 143*y2*z4 + 3*y2)/(64*sqrt(pi))
+		dy += (float)dL_dy(59) * (0.93875360317376422*xy*(-66.0*z2 + 143.0*z4 + 3.0));                         // 9*sqrt(35)*xy*(-66*z2 + 143*z4 + 3)/(32*sqrt(pi))
+		dz += (float)dL_dy(59) * (-6.8841930899409371*xz*(x2 - 3.0*y2)*(13.0*z2 - 3.0));                               // -33*sqrt(35)*xz*(x2 - 3*y2)*(13*z2 - 3)/(16*sqrt(pi))
+		dx += (float)dL_dy(60) * (4.1513246297620823*xz*(x2 - 3.0*y2)*(13.0*z2 - 3.0));                                // 3*sqrt(385)*xz*(x2 - 3*y2)*(13*z2 - 3)/(8*sqrt(pi))
+		dy += (float)dL_dy(60) * (-4.1513246297620823*yz*(3.0*x2 - y2)*(13.0*z2 - 3.0));                               // -3*sqrt(385)*yz*(3*x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
+		dz += (float)dL_dy(60) * (3.1134934723215619*(13.0*z2 - 1.0)*(-6.0*x2*y2 + x4 + y4));                          // 9*sqrt(385)*(13*z2 - 1)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
+		dx += (float)dL_dy(61) * (-0.51891557872026028*(13.0*z2 - 1.0)*(-10.0*x2*y2 + 4.0*x2*(x2 - 5.0*y2) + x4 + 5.0*y4));                            // -3*sqrt(385)*(13*z2 - 1)*(-10*x2*y2 + 4*x2*(x2 - 5*y2) + x4 + 5*y4)/(64*sqrt(pi))
+		dy += (float)dL_dy(61) * (10.378311574405206*xy*(x2 - y2)*(13.0*z2 - 1.0));                            // 15*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(16*sqrt(pi))
+		dz += (float)dL_dy(61) * (13.491805046726766*xz*(10.0*x2*y2 - x4 - 5.0*y4));                           // 39*sqrt(385)*xz*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
+		dx += (float)dL_dy(62) * (15.875763970811402*xz*(-10.0*x2*y2 + x4 + 5.0*y4));                          // 9*sqrt(10010)*xz*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
+		dy += (float)dL_dy(62) * (15.875763970811402*yz*(10.0*x2*y2 - 5.0*x4 - y4));                           // 9*sqrt(10010)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		dz += (float)dL_dy(62) * (39.6894099270285*x2*y4 - 39.6894099270285*x4*y2 + 2.6459606618019*x6 - 2.6459606618019*y6);                          // 3*sqrt(10010)*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
+		dx += (float)dL_dy(63) * (-74.252086915082614*x2*y4 + 74.252086915082614*x4*y2 - 4.9501391276721742*x6 + 4.9501391276721742*y6);                               // 21*sqrt(715)*(-15*x2*y4 + 15*x4*y2 - x6 + y6)/(64*sqrt(pi))
+		dy += (float)dL_dy(63) * (9.9002782553443485*xy*(-10.0*x2*y2 + 3.0*x4 + 3.0*y4));                              // 21*sqrt(715)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
+		// dz += (float)dL_dy(63) * (0);                               // 0
 	};
 
 	compute_grad();
@@ -389,9 +385,9 @@ __global__ void kernel_sh_backward(
 	// Multiplication by 2 due to the conversion
 	// from [0,1]^3 to directions in [-1,1]^3.
 	// See implementation in `kernel_sh`.
-	dL_dx(i)[0] = dx * 2.0f;
-	dL_dx(i)[1] = dy * 2.0f;
-	dL_dx(i)[2] = dz * 2.0f;
+	dL_dx(0, i) = dx * 2.0f;
+	dL_dx(1, i) = dy * 2.0f;
+	dL_dx(2, i) = dz * 2.0f;
 }
 
 template <typename T>
@@ -429,9 +425,8 @@ public:
 			input.n(),
 			m_degree,
 			m_n_to_pad,
-			output->layout(),
-			input.pitched_ptr(),
-			output->pitched_ptr()
+			input.view(),
+			output->view()
 		);
 
 		return std::make_unique<Context>();
@@ -451,16 +446,13 @@ public:
 			return;
 		}
 
-		CHECK_THROW(dL_doutput.layout() == output.layout());
-
 		linear_kernel(kernel_sh_backward<T>, 0, stream,
 			input.n(),
 			m_degree,
 			m_n_to_pad,
-			output.layout(),
-			dL_doutput.pitched_ptr(),
-			input.pitched_ptr(),
-			dL_dinput->pitched_ptr()
+			dL_doutput.view(),
+			input.view(),
+			dL_dinput->view()
 		);
 	}
 

--- a/include/tiny-cuda-nn/encodings/spherical_harmonics.h
+++ b/include/tiny-cuda-nn/encodings/spherical_harmonics.h
@@ -414,7 +414,7 @@ public:
 		}
 	}
 
-	std::unique_ptr<Context> forward(
+	std::unique_ptr<Context> forward_impl(
 		cudaStream_t stream,
 		const GPUMatrixDynamic<float>& input,
 		GPUMatrixDynamic<T>* output = nullptr,
@@ -437,7 +437,7 @@ public:
 		return std::make_unique<Context>();
 	}
 
-	void backward(
+	void backward_impl(
 		cudaStream_t stream,
 		const Context& ctx,
 		const GPUMatrixDynamic<float>& input,

--- a/include/tiny-cuda-nn/encodings/triangle_wave.h
+++ b/include/tiny-cuda-nn/encodings/triangle_wave.h
@@ -116,7 +116,7 @@ public:
 		m_n_padded_output_dims = m_n_output_dims = m_n_dims_to_encode * m_n_frequencies;
 	}
 
-	std::unique_ptr<Context> forward(
+	std::unique_ptr<Context> forward_impl(
 		cudaStream_t stream,
 		const GPUMatrixDynamic<float>& input,
 		GPUMatrixDynamic<T>* output = nullptr,
@@ -146,7 +146,7 @@ public:
 		return forward;
 	}
 
-	void backward(
+	void backward_impl(
 		cudaStream_t stream,
 		const Context& ctx,
 		const GPUMatrixDynamic<float>& input,

--- a/include/tiny-cuda-nn/networks/cutlass_mlp.h
+++ b/include/tiny-cuda-nn/networks/cutlass_mlp.h
@@ -53,11 +53,11 @@ public:
 	);
 	~CutlassMLP() override;
 
-	void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params = true) override;
+	void inference_mixed_precision_impl(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params = true) override;
 
-	std::unique_ptr<Context> forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_params = false, bool prepare_input_gradients = false) override;
+	std::unique_ptr<Context> forward_impl(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_params = false, bool prepare_input_gradients = false) override;
 
-	void backward(
+	void backward_impl(
 		cudaStream_t stream,
 		const Context& ctx,
 		const GPUMatrixDynamic<T>& input,

--- a/include/tiny-cuda-nn/networks/fully_fused_mlp.h
+++ b/include/tiny-cuda-nn/networks/fully_fused_mlp.h
@@ -46,11 +46,11 @@ public:
 	FullyFusedMLP(uint32_t input_width, uint32_t output_width, uint32_t n_hidden_layers, bool use_feedback_alignment, Activation activation, Activation output_activation);
 	~FullyFusedMLP() override;
 
-	void inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params = true) override;
+	void inference_mixed_precision_impl(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params = true) override;
 
-	std::unique_ptr<Context> forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_params = false, bool prepare_input_gradients = false) override;
+	std::unique_ptr<Context> forward_impl(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output = nullptr, bool use_inference_params = false, bool prepare_input_gradients = false) override;
 
-	void backward(
+	void backward_impl(
 		cudaStream_t stream,
 		const Context& ctx,
 		const GPUMatrixDynamic<T>& input,

--- a/src/cutlass_mlp.cu
+++ b/src/cutlass_mlp.cu
@@ -150,9 +150,7 @@ bool compute_inference_layer(
 }
 
 template <typename T>
-void CutlassMLP<T>::inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params) {
-	this->check_inference_mixed_precision_args(input, output);
-
+void CutlassMLP<T>::inference_mixed_precision_impl(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params) {
 	// If there are no hidden layers, the network is just a simple matmul.
 	if (m_n_hidden_layers == 0) {
 		compute_inference_layer<LastLayer>(stream, m_output_activation, input_weight_matrix(use_inference_params), input, output);
@@ -186,9 +184,7 @@ void CutlassMLP<T>::inference_mixed_precision(cudaStream_t stream, const GPUMatr
 }
 
 template <typename T>
-std::unique_ptr<Context> CutlassMLP<T>::forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output, bool use_inference_params, bool prepare_input_gradients) {
-	this->check_forward_args(input, output);
-
+std::unique_ptr<Context> CutlassMLP<T>::forward_impl(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output, bool use_inference_params, bool prepare_input_gradients) {
 	// If there are no hidden layers, the network is just a simple matmul. No tmp buffers required
 	if (m_n_hidden_layers == 0) {
 		if (output) {
@@ -237,7 +233,7 @@ std::unique_ptr<Context> CutlassMLP<T>::forward(cudaStream_t stream, const GPUMa
 }
 
 template <typename T>
-void CutlassMLP<T>::backward(
+void CutlassMLP<T>::backward_impl(
 	cudaStream_t stream,
 	const Context& ctx,
 	const GPUMatrixDynamic<T>& input,
@@ -247,8 +243,6 @@ void CutlassMLP<T>::backward(
 	bool use_inference_params,
 	EGradientMode param_gradients_mode
 ) {
-	this->check_backward_args(input, output, dL_doutput, dL_dinput);
-
 	// Make sure our temporary buffers have the correct size for the given batch size
 	uint32_t batch_size = dL_doutput.n();
 

--- a/src/fully_fused_mlp.cu
+++ b/src/fully_fused_mlp.cu
@@ -716,9 +716,7 @@ void compute_inference_layer(
 }
 
 template <typename T, int WIDTH>
-void FullyFusedMLP<T, WIDTH>::inference_mixed_precision(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params) {
-	this->check_inference_mixed_precision_args(input, output);
-
+void FullyFusedMLP<T, WIDTH>::inference_mixed_precision_impl(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>& output, bool use_inference_params) {
 	// Make sure our temporary buffers have the correct size for the given batch size
 	uint32_t batch_size = input.n();
 
@@ -745,9 +743,7 @@ void FullyFusedMLP<T, WIDTH>::inference_mixed_precision(cudaStream_t stream, con
 }
 
 template <typename T, int WIDTH>
-std::unique_ptr<Context> FullyFusedMLP<T, WIDTH>::forward(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output, bool use_inference_params, bool prepare_input_gradients) {
-	this->check_forward_args(input, output);
-
+std::unique_ptr<Context> FullyFusedMLP<T, WIDTH>::forward_impl(cudaStream_t stream, const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<T>* output, bool use_inference_params, bool prepare_input_gradients) {
 	// Make sure our temporary buffers have the correct size for the given batch size
 	uint32_t batch_size = input.n();
 	auto forward = allocate_forward_buffers(stream, batch_size);
@@ -775,7 +771,7 @@ std::unique_ptr<Context> FullyFusedMLP<T, WIDTH>::forward(cudaStream_t stream, c
 }
 
 template <typename T, int WIDTH>
-void FullyFusedMLP<T, WIDTH>::backward(
+void FullyFusedMLP<T, WIDTH>::backward_impl(
 	cudaStream_t stream,
 	const Context& ctx,
 	const GPUMatrixDynamic<T>& input,
@@ -785,8 +781,6 @@ void FullyFusedMLP<T, WIDTH>::backward(
 	bool use_inference_params,
 	EGradientMode param_gradients_mode
 ) {
-	this->check_backward_args(input, output, dL_doutput, dL_dinput);
-
 	// Make sure our temporary buffers have the correct size for the given batch size
 	uint32_t batch_size = dL_doutput.n();
 


### PR DESCRIPTION
This PR progresses __tiny-cuda-nn__'s overhaul for all differentiable components to support arbitrarily laid out data.

The last remaining component that still needs to be given support for SoA / strided data is `Loss<T>`.

Anothing (yet missing) TODO item is to extend the PyTorch bindings to exploit this functionality. Currently, PyTorch tensors are transformed to AoS layout before being passed to __tiny-cuda-nn__, which no longer has to happen.