### PR TITLE
`GridEncoding`: add additional hash functions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
-            cuda: "11.3"
+          - os: ubuntu-22.04
+            cuda: "11.7"
             arch: 86
           - os: ubuntu-18.04
             cuda: "10.2"
@@ -53,7 +53,6 @@ jobs:
       - name: Build
         working-directory: ${{ env.build_dir }}
         run: cmake --build . --target all --verbose -j `nproc`
-
 
   build_windows:
     name: Build on Windows


### PR DESCRIPTION
- Incoherent version of the prime hash (first prime isn't 1)
- Reversed prime hash (can act as a hash with "different seed" for low dimensions)
- Slow PCG32-based hash that has much better pseudorandomness