### PR TITLE
fix gradient flow

### DIFF
--- a/include/tiny-cuda-nn/network_with_input_encoding.h
+++ b/include/tiny-cuda-nn/network_with_input_encoding.h
@@ -74,7 +74,7 @@ public:
 
 		forward->network_input = GPUMatrixDynamic<T>{m_encoding->padded_output_width(), input.n(), stream, m_encoding->preferred_output_layout()};
 		forward->encoding_ctx = m_encoding->forward(stream, input, &forward->network_input, use_inference_params, prepare_input_gradients);
-		forward->network_ctx = m_network->forward(stream, forward->network_input, output, use_inference_params, prepare_input_gradients);
+		forward->network_ctx = m_network->forward(stream, forward->network_input, output, use_inference_params, true);
 
 		return forward;
 	}


### PR DESCRIPTION
It looks like there is a mistake in a code regarding the gradient flow. We need gradients of the network with respect to input to calculate the gradients of the encodings. This doesn't change anything currently since both cutlass and fully fused mlp ignore this flag and prepare the gradient wrp to input anyways. However, it can be an issue for somebody who would want to implement their own network. 