### PR TITLE
Overhaul alignment and padding of `Encoding`

### DIFF
--- a/include/tiny-cuda-nn/encoding.h
+++ b/include/tiny-cuda-nn/encoding.h
@@ -71,8 +71,8 @@ public:
 		this->forward(stream, input, &output, use_inference_params, false);
 	}
 
-	virtual void set_alignment(uint32_t alignment) = 0;
-	virtual uint32_t min_alignment() const = 0;
+	virtual void set_padded_output_width(uint32_t padded_output_width) = 0;
+	virtual uint32_t required_output_alignment() const = 0;
 
 	virtual MatrixLayout preferred_output_layout() const = 0;
 
@@ -82,6 +82,10 @@ public:
 	size_t n_params() const override { return 0; }
 
 	std::vector<std::pair<uint32_t, uint32_t>> layer_sizes() const override { return {}; }
+
+	void set_alignment(uint32_t alignment) {
+		this->set_padded_output_width(next_multiple(this->output_width(), lcm(alignment, this->required_output_alignment())));
+	}
 };
 
 template <typename T>

--- a/include/tiny-cuda-nn/encodings/identity.h
+++ b/include/tiny-cuda-nn/encodings/identity.h
@@ -92,7 +92,7 @@ class IdentityEncoding : public Encoding<T> {
 public:
 	IdentityEncoding(uint32_t n_dims_to_encode, float scale = 1.0f, float offset = 0.0f)
 	: m_n_dims_to_encode{n_dims_to_encode}, m_scale{scale}, m_offset{offset} {
-		m_n_padded_output_dims = m_n_output_dims = m_n_dims_to_encode;
+		m_n_output_dims = m_n_dims_to_encode;
 	}
 
 	std::unique_ptr<Context> forward_impl(
@@ -102,7 +102,7 @@ public:
 		bool use_inference_params = false,
 		bool prepare_input_gradients = false
 	) override {
-		if (!output || m_n_padded_output_dims == 0) {
+		if (!output || padded_output_width() == 0) {
 			return std::make_unique<Context>();
 		}
 
@@ -130,7 +130,7 @@ public:
 		bool use_inference_params = false,
 		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override {
-		if (!dL_dinput || m_n_padded_output_dims == 0) {
+		if (!dL_dinput || padded_output_width() == 0) {
 			return;
 		}
 
@@ -149,24 +149,23 @@ public:
 	}
 
 	uint32_t padded_output_width() const override {
-		return m_n_padded_output_dims;
+		return m_n_output_dims + m_n_to_pad;
 	}
 
 	uint32_t output_width() const override {
-		return m_n_padded_output_dims;
+		return padded_output_width();
 	}
 
 	uint32_t required_input_alignment() const override {
 		return 1;
 	}
 
-	void set_alignment(uint32_t alignment) override {
-		alignment = lcm(alignment, min_alignment());
-		m_n_padded_output_dims = next_multiple(m_n_output_dims, alignment);
-		m_n_to_pad = m_n_padded_output_dims - m_n_output_dims;
+	void set_padded_output_width(uint32_t padded_output_width) override {
+		CHECK_THROW(padded_output_width >= m_n_output_dims);
+		m_n_to_pad = padded_output_width - m_n_output_dims;
 	}
 
-	uint32_t min_alignment() const override {
+	uint32_t required_output_alignment() const override {
 		return 1;
 	}
 
@@ -190,7 +189,6 @@ private:
 
 	// derived sizes
 	uint32_t m_n_output_dims;
-	uint32_t m_n_padded_output_dims;
 	uint32_t m_n_to_pad = 0;
 };
 

--- a/include/tiny-cuda-nn/encodings/spherical_harmonics.h
+++ b/include/tiny-cuda-nn/encodings/spherical_harmonics.h
@@ -395,7 +395,7 @@ class SphericalHarmonicsEncoding : public Encoding<T> {
 public:
 	SphericalHarmonicsEncoding(uint32_t degree, uint32_t n_dims_to_encode)
 	: m_degree{degree}, m_n_dims_to_encode{n_dims_to_encode} {
-		m_n_padded_output_dims = m_n_output_dims = degree * degree;
+		m_n_output_dims = degree * degree;
 
 		if (n_dims_to_encode != 3) {
 			throw std::runtime_error{"Can only encode 3D directions in spherical harmonics."};
@@ -417,7 +417,7 @@ public:
 		bool use_inference_params = false,
 		bool prepare_input_gradients = false
 	) override {
-		if (!output || m_n_padded_output_dims == 0) {
+		if (!output || padded_output_width() == 0) {
 			return std::make_unique<Context>();
 		}
 
@@ -442,7 +442,7 @@ public:
 		bool use_inference_params = false,
 		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override {
-		if (!dL_dinput || m_n_padded_output_dims == 0) {
+		if (!dL_dinput || padded_output_width() == 0) {
 			return;
 		}
 
@@ -461,24 +461,23 @@ public:
 	}
 
 	uint32_t padded_output_width() const override {
-		return m_n_padded_output_dims;
+		return m_n_output_dims + m_n_to_pad;
 	}
 
 	uint32_t output_width() const override {
-		return m_n_padded_output_dims;
+		return padded_output_width();
 	}
 
 	uint32_t required_input_alignment() const override {
 		return 1;
 	}
 
-	void set_alignment(uint32_t alignment) override {
-		alignment = lcm(alignment, min_alignment());
-		m_n_padded_output_dims = next_multiple(m_n_output_dims, alignment);
-		m_n_to_pad = m_n_padded_output_dims - m_n_output_dims;
+	void set_padded_output_width(uint32_t padded_output_width) override {
+		CHECK_THROW(padded_output_width >= m_n_output_dims);
+		m_n_to_pad = padded_output_width - m_n_output_dims;
 	}
 
-	uint32_t min_alignment() const override {
+	uint32_t required_output_alignment() const override {
 		return 1;
 	}
 
@@ -500,7 +499,6 @@ private:
 
 	// derived sizes
 	uint32_t m_n_output_dims;
-	uint32_t m_n_padded_output_dims;
 	uint32_t m_n_to_pad = 0;
 };
 

--- a/include/tiny-cuda-nn/encodings/triangle_wave.h
+++ b/include/tiny-cuda-nn/encodings/triangle_wave.h
@@ -113,7 +113,7 @@ class TriangleWaveEncoding : public Encoding<T> {
 public:
 	TriangleWaveEncoding(uint32_t n_frequencies, uint32_t n_dims_to_encode)
 	: m_n_frequencies{n_frequencies}, m_n_dims_to_encode{n_dims_to_encode} {
-		m_n_padded_output_dims = m_n_output_dims = m_n_dims_to_encode * m_n_frequencies;
+		m_n_output_dims = m_n_dims_to_encode * m_n_frequencies;
 	}
 
 	std::unique_ptr<Context> forward_impl(
@@ -125,7 +125,7 @@ public:
 	) override {
 		auto forward = std::make_unique<ForwardContext>();
 
-		if (!output || m_n_padded_output_dims == 0) {
+		if (!output || padded_output_width() == 0) {
 			return forward;
 		}
 
@@ -156,7 +156,7 @@ public:
 		bool use_inference_params = false,
 		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override {
-		if (!dL_dinput || m_n_padded_output_dims == 0) {
+		if (!dL_dinput || padded_output_width() == 0) {
 			return;
 		}
 
@@ -177,24 +177,23 @@ public:
 	}
 
 	uint32_t padded_output_width() const override {
-		return m_n_padded_output_dims;
+		return m_n_output_dims + m_n_to_pad;
 	}
 
 	uint32_t output_width() const override {
-		return m_n_padded_output_dims;
+		return padded_output_width();
 	}
 
 	uint32_t required_input_alignment() const override {
 		return 1;
 	}
 
-	void set_alignment(uint32_t alignment) override {
-		alignment = lcm(alignment, min_alignment());
-		m_n_padded_output_dims = next_multiple(m_n_output_dims, alignment);
-		m_n_to_pad = m_n_padded_output_dims - m_n_output_dims;
+	void set_padded_output_width(uint32_t padded_output_width) override {
+		CHECK_THROW(padded_output_width >= m_n_output_dims);
+		m_n_to_pad = padded_output_width - m_n_output_dims;
 	}
 
-	uint32_t min_alignment() const override {
+	uint32_t required_output_alignment() const override {
 		return 1;
 	}
 
@@ -219,7 +218,6 @@ private:
 
 	// derived sizes
 	uint32_t m_n_output_dims;
-	uint32_t m_n_padded_output_dims;
 	uint32_t m_n_to_pad = 0;
 };
 


### PR DESCRIPTION
Decouples padding from alignment, thus working around an inherent issue described in #145 