### PR TITLE
Fix MAPE formula

### DIFF
--- a/samples/mlp_learning_an_image_pytorch.py
+++ b/samples/mlp_learning_an_image_pytorch.py
@@ -155,7 +155,7 @@ if __name__ == "__main__":
 		targets = traced_image(batch)
 		output = model(batch)
 
-		relative_l2_error = (output - targets.to(output.dtype))**2 / (output.detach()**2 + 0.01)
+		relative_l2_error = (output - targets.to(output.dtype))**2 / (targets.to(output.dtype)**2 + 0.01)
 		loss = relative_l2_error.mean()
 
 		optimizer.zero_grad()


### PR DESCRIPTION
The Mean absolute percentage error formula divides by the target, not the predicted value. See formula in paper or at https://en.wikipedia.org/wiki/Mean_absolute_percentage_error.

