### PR TITLE
fix bug: unordered_map::erase causes segmentation fault when map is empty

### DIFF
--- a/include/tiny-cuda-nn/gpu_memory.h
+++ b/include/tiny-cuda-nn/gpu_memory.h
@@ -742,9 +742,13 @@ std::tuple<Types*...> allocate_workspace_and_distribute(cudaStream_t stream, GPU
 
 inline void free_gpu_memory_arena(cudaStream_t stream) {
 	if (stream) {
-		stream_gpu_memory_arenas().erase(stream);
+		if (!stream_gpu_memory_arenas().empty()) {
+			stream_gpu_memory_arenas().erase(stream);
+		}
 	} else {
-		global_gpu_memory_arenas().erase(cuda_device());
+		if (!global_gpu_memory_arenas().empty()) {
+			global_gpu_memory_arenas().erase(cuda_device());
+		}
 	}
 }
 


### PR DESCRIPTION
#159 