### PR TITLE
half precision NetworkWithInputEncoding input 

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Following is a summary of the components of this framework. [The JSON documentat
 | Exponential Decay | `include/tiny-cuda-nn/optimizers/exponential_decay.h` | Wraps another optimizer and performs piecewise-constant exponential learning-rate decay.
 | Lookahead | `include/tiny-cuda-nn/optimizers/lookahead.h` | Wraps another optimizer, implementing the lookahead algorithm [[Zhang et al. 2019]](https://arxiv.org/abs/1907.08610).
 
+| Composite | `include/tiny-cuda-nn/optimizers/composite.h` | Allows using several optimizers on different parameters 
+
 
 ## License and Citation
 

--- a/README.md
+++ b/README.md
@@ -201,10 +201,10 @@ Following is a summary of the components of this framework. [The JSON documentat
 | Shampoo | `include/tiny-cuda-nn/optimizers/shampoo.h` | Implementation of the 2nd order Shampoo optimizer [[Gupta et al. 2018]](https://arxiv.org/abs/1802.09568) with home-grown optimizations as well as those by [Anil et al. [2020]](https://arxiv.org/abs/2002.09018).
 | Average | `include/tiny-cuda-nn/optimizers/average.h` | Wraps another optimizer and computes a linear average of the weights over the last N iterations. The average is used for inference only (does not feed back into training).
 | Batched | `include/tiny-cuda-nn/optimizers/batched.h` | Wraps another optimizer, invoking the nested optimizer once every N steps on the averaged gradient. Has the same effect as increasing the batch size but requires only a constant amount of memory. |
+| Composite | `include/tiny-cuda-nn/optimizers/composite.h` | Allows using several optimizers on different parameters. 
 | EMA | `include/tiny-cuda-nn/optimizers/average.h` | Wraps another optimizer and computes an exponential moving average of the weights. The average is used for inference only (does not feed back into training).
 | Exponential Decay | `include/tiny-cuda-nn/optimizers/exponential_decay.h` | Wraps another optimizer and performs piecewise-constant exponential learning-rate decay.
 | Lookahead | `include/tiny-cuda-nn/optimizers/lookahead.h` | Wraps another optimizer, implementing the lookahead algorithm [[Zhang et al. 2019]](https://arxiv.org/abs/1907.08610).
-| Composite | `include/tiny-cuda-nn/optimizers/composite.h` | Allows using several optimizers on different parameters 
 
 
 ## License and Citation

--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ Following is a summary of the components of this framework. [The JSON documentat
 | EMA | `include/tiny-cuda-nn/optimizers/average.h` | Wraps another optimizer and computes an exponential moving average of the weights. The average is used for inference only (does not feed back into training).
 | Exponential Decay | `include/tiny-cuda-nn/optimizers/exponential_decay.h` | Wraps another optimizer and performs piecewise-constant exponential learning-rate decay.
 | Lookahead | `include/tiny-cuda-nn/optimizers/lookahead.h` | Wraps another optimizer, implementing the lookahead algorithm [[Zhang et al. 2019]](https://arxiv.org/abs/1907.08610).
-
 | Composite | `include/tiny-cuda-nn/optimizers/composite.h` | Allows using several optimizers on different parameters 
 
 

--- a/include/tiny-cuda-nn/common_device.h
+++ b/include/tiny-cuda-nn/common_device.h
@@ -430,56 +430,67 @@ __device__ inline void pos_fract(const float input, float* pos, uint32_t* pos_gr
 	*pos = interpolation_fun(*pos);
 }
 
-__device__ inline float weight_decay(float relative_weight_decay, float absolute_weight_decay, float weight) {
+template <typename T>
+__device__ inline T weight_decay(T relative_weight_decay, T absolute_weight_decay, T weight) {
 	// Relative weight decay is closely related to l2 regularization, whereas absolute weight decay corresponds to l1 regularization
 	return (1 - relative_weight_decay) * weight - copysignf(absolute_weight_decay, weight);
 }
 
-__device__ inline float gaussian_cdf(const float x, const float inv_radius) {
+template <typename T>
+__device__ inline T gaussian_cdf(const T x, const T inv_radius) {
 	return normcdff(x * inv_radius);
 }
 
-__device__ inline float gaussian_cdf_approx(const float x, const float inv_radius) {
-	static constexpr float MAGIC_SIGMOID_FACTOR = 1.12f / SQRT2;
+template <typename T>
+__device__ inline T gaussian_cdf_approx(const T x, const T inv_radius) {
+	static constexpr T MAGIC_SIGMOID_FACTOR = 1.12f / SQRT2;
 	return logistic(MAGIC_SIGMOID_FACTOR * x * inv_radius);
 }
 
-__device__ inline float gaussian_cdf_approx_derivative(const float result, const float inv_radius) {
-	static constexpr float MAGIC_SIGMOID_FACTOR = 1.12f / SQRT2;
+template <typename T>
+__device__ inline T gaussian_cdf_approx_derivative(const T result, const T inv_radius) {
+	static constexpr T MAGIC_SIGMOID_FACTOR = 1.12f / SQRT2;
 	return result * (1 - result) * MAGIC_SIGMOID_FACTOR * inv_radius;
 }
 
-__device__ inline float gaussian_pdf(const float x, const float inv_radius) {
+template <typename T>
+__device__ inline T gaussian_pdf(const T x, const T inv_radius) {
 	return inv_radius * rsqrtf(2.0f * PI) * expf(-0.5f * (x * x * inv_radius * inv_radius));
 }
 
-__device__ inline float gaussian_pdf_max_1(const float x, const float inv_radius) {
+template <typename T>
+__device__ inline T gaussian_pdf_max_1(const T x, const T inv_radius) {
 	return expf(-0.5f * (x * x * inv_radius * inv_radius));
 }
 
-__device__ inline float tent(const float x, const float inv_radius) {
+template <typename T>
+__device__ inline T tent(const T x, const T inv_radius) {
 	return fmaxf(1.0f - fabsf(x * inv_radius), 0.0f);
 }
 
-__device__ inline float tent_cdf(const float x, const float inv_radius) {
+template <typename T>
+__device__ inline T tent_cdf(const T x, const T inv_radius) {
 	return fmaxf(0.0f, fminf(1.0f, x * inv_radius + 0.5f));
 }
 
-__device__ inline float quartic(const float x, const float inv_radius) {
-	const float u = x * inv_radius;
-	const float tmp = fmaxf(1 - u*u, 0.0f);
-	return ((float)15 / 16) * tmp * tmp;
+template <typename T>
+__device__ inline T quartic(const T x, const T inv_radius) {
+	const T u = x * inv_radius;
+	const T tmp = fmaxf((T)1 - u*u, 0.0f);
+	return ((T)15 / (T)16) * tmp * tmp;
 }
 
-__device__ inline float quartic_cdf_deriv(const float x, const float inv_radius) {
+template <typename T>
+__device__ inline T quartic_cdf_deriv(const T x, const T inv_radius) {
 	return quartic(x, inv_radius) * inv_radius;
 }
 
-__device__ inline float quartic_cdf(const float x, const float inv_radius) {
-	const float u = x * inv_radius;
-	const float u2 = u * u;
-	const float u4 = u2 * u2;
-	return fmaxf(0.0f, fminf(1.0f, ((float)15 / 16) * u * (1 - ((float)2 / 3) * u2 + ((float)1 / 5) * u4) + 0.5f));
+template <typename T>
+__device__ inline T quartic_cdf(const T x, const T inv_radius) {
+	const T u = x * inv_radius;
+	const T u2 = u * u;
+	const T u4 = u2 * u2;
+	return std::max((T)0.0, std::min((T)1.0, ((T)15 / (T)16) * u * ((T)1 - ((T)2 / (T)3) * u2 + ((T)1 / (T)5) * u4) + (T)0.5));
 }
 
 __device__ inline uint32_t permute(uint32_t num, uint32_t size) {

--- a/include/tiny-cuda-nn/encoding.h
+++ b/include/tiny-cuda-nn/encoding.h
@@ -57,14 +57,14 @@ ReductionType string_to_reduction_type(const std::string& reduction_type);
 
 std::string to_string(ReductionType reduction_type);
 
-template <typename T>
-class Encoding : public DifferentiableObject<float, T, T> {
+template <typename T, typename INPUT_T = float>
+class Encoding : public DifferentiableObject<INPUT_T, T, T> {
 public:
 	virtual ~Encoding() { }
 
 	void inference_mixed_precision_impl(
 		cudaStream_t stream,
-		const GPUMatrixDynamic<float>& input,
+		const GPUMatrixDynamic<INPUT_T>& input,
 		GPUMatrixDynamic<T>& output,
 		bool use_inference_params = true
 	) override {
@@ -88,7 +88,7 @@ public:
 	}
 };
 
-template <typename T>
-Encoding<T>* create_encoding(uint32_t n_dims_to_encode, const json& params, uint32_t alignment = 8);
+template <typename T, typename INPUT_T = float>
+Encoding<T, INPUT_T>* create_encoding(uint32_t n_dims_to_encode, const json& params, uint32_t alignment = 8);
 
 TCNN_NAMESPACE_END

--- a/include/tiny-cuda-nn/encodings/composite.h
+++ b/include/tiny-cuda-nn/encodings/composite.h
@@ -145,7 +145,6 @@ public:
 		m_reduction_type = string_to_reduction_type(params.value("reduction", "Concatenation"));
 
 		const json::array_t& nested = params["nested"];
-
 		uint32_t total_nested_dims_to_encode = 0;
 		for (size_t i = 0; i < nested.size(); ++i) {
 			total_nested_dims_to_encode += nested[i].value("n_dims_to_encode", 0);

--- a/include/tiny-cuda-nn/encodings/spherical_harmonics.h
+++ b/include/tiny-cuda-nn/encodings/spherical_harmonics.h
@@ -43,12 +43,12 @@
 
 TCNN_NAMESPACE_BEGIN
 
-template <typename T>
+template <typename T, typename INPUT_T>
 __global__ void kernel_sh(
 	const uint32_t num_elements,
 	const uint32_t degree,
 	const uint32_t num_to_pad,
-	MatrixView<const float> data_in,
+	MatrixView<const INPUT_T> data_in,
 	MatrixView<T> data_out
 ) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
@@ -63,321 +63,321 @@ __global__ void kernel_sh(
 
 	data_out.advance_rows(num_to_pad);
 
-	float x = data_in(0, i) * 2.f - 1.f;
-	float y = data_in(1, i) * 2.f - 1.f;
-	float z = data_in(2, i) * 2.f - 1.f;
+	INPUT_T x = data_in(0, i) * INPUT_T(2) - INPUT_T(1);
+	INPUT_T y = data_in(1, i) * INPUT_T(2) - INPUT_T(1);
+	INPUT_T z = data_in(2, i) * INPUT_T(2) - INPUT_T(1);
 
 	// Let compiler figure out how to sequence/reorder these calculations w.r.t. branches
-	float xy=x*y, xz=x*z, yz=y*z, x2=x*x, y2=y*y, z2=z*z;
-	float x4=x2*x2, y4=y2*y2, z4=z2*z2;
-	float x6=x4*x2, y6=y4*y2, z6=z4*z2;
+	INPUT_T xy=x*y, xz=x*z, yz=y*z, x2=x*x, y2=y*y, z2=z*z;
+	INPUT_T x4=x2*x2, y4=y2*y2, z4=z2*z2;
+	INPUT_T x6=x4*x2, y6=y4*y2, z6=z4*z2;
 
 	// SH polynomials generated using scripts/gen_sh.py based on the recurrence relations in appendix A1 of https://www.ppsloan.org/publications/StupidSH36.pdf
 
 	auto write_sh = [&]() {
-		data_out(0) = 0.28209479177387814f;                          // 1/(2*sqrt(pi))
+		data_out(0) = INPUT_T(0.28209479177387814);                          // 1/(2*sqrt(pi))
 		if (degree <= 1) { return; }
-		data_out(1) = -0.48860251190291987f*y;                               // -sqrt(3)*y/(2*sqrt(pi))
-		data_out(2) = 0.48860251190291987f*z;                                // sqrt(3)*z/(2*sqrt(pi))
-		data_out(3) = -0.48860251190291987f*x;                               // -sqrt(3)*x/(2*sqrt(pi))
+		data_out(1) = -INPUT_T(0.48860251190291987)*y;                               // -sqrt(3)*y/(2*sqrt(pi))
+		data_out(2) = INPUT_T(0.48860251190291987)*z;                                // sqrt(3)*z/(2*sqrt(pi))
+		data_out(3) = -INPUT_T(0.48860251190291987)*x;                               // -sqrt(3)*x/(2*sqrt(pi))
 		if (degree <= 2) { return; }
-		data_out(4) = 1.0925484305920792f*xy;                                // sqrt(15)*xy/(2*sqrt(pi))
-		data_out(5) = -1.0925484305920792f*yz;                               // -sqrt(15)*yz/(2*sqrt(pi))
-		data_out(6) = 0.94617469575755997f*z2 - 0.31539156525251999f;                         // sqrt(5)*(3*z2 - 1)/(4*sqrt(pi))
-		data_out(7) = -1.0925484305920792f*xz;                               // -sqrt(15)*xz/(2*sqrt(pi))
-		data_out(8) = 0.54627421529603959f*x2 - 0.54627421529603959f*y2;                              // sqrt(15)*(x2 - y2)/(4*sqrt(pi))
+		data_out(4) = INPUT_T(1.0925484305920792)*xy;                                // sqrt(15)*xy/(2*sqrt(pi))
+		data_out(5) = -INPUT_T(1.0925484305920792)*yz;                               // -sqrt(15)*yz/(2*sqrt(pi))
+		data_out(6) = INPUT_T(0.94617469575755997)*z2 - INPUT_T(0.31539156525251999);                         // sqrt(5)*(3*z2 - 1)/(4*sqrt(pi))
+		data_out(7) = -INPUT_T(1.0925484305920792)*xz;                               // -sqrt(15)*xz/(2*sqrt(pi))
+		data_out(8) = INPUT_T(0.54627421529603959)*x2 - INPUT_T(0.54627421529603959)*y2;                              // sqrt(15)*(x2 - y2)/(4*sqrt(pi))
 		if (degree <= 3) { return; }
-		data_out(9) = 0.59004358992664352f*y*(-3.0f*x2 + y2);                         // sqrt(70)*y*(-3*x2 + y2)/(8*sqrt(pi))
-		data_out(10) = 2.8906114426405538f*xy*z;                             // sqrt(105)*xy*z/(2*sqrt(pi))
-		data_out(11) = 0.45704579946446572f*y*(1.0f - 5.0f*z2);                                // sqrt(42)*y*(1 - 5*z2)/(8*sqrt(pi))
-		data_out(12) = 0.3731763325901154f*z*(5.0f*z2 - 3.0f);                         // sqrt(7)*z*(5*z2 - 3)/(4*sqrt(pi))
-		data_out(13) = 0.45704579946446572f*x*(1.0f - 5.0f*z2);                                // sqrt(42)*x*(1 - 5*z2)/(8*sqrt(pi))
-		data_out(14) = 1.4453057213202769f*z*(x2 - y2);                              // sqrt(105)*z*(x2 - y2)/(4*sqrt(pi))
-		data_out(15) = 0.59004358992664352f*x*(-x2 + 3.0f*y2);                                // sqrt(70)*x*(-x2 + 3*y2)/(8*sqrt(pi))
+		data_out(9) = INPUT_T(0.59004358992664352)*y*(-INPUT_T(3.0)*x2 + y2);                         // sqrt(70)*y*(-3*x2 + y2)/(8*sqrt(pi))
+		data_out(10) = INPUT_T(2.8906114426405538)*xy*z;                             // sqrt(105)*xy*z/(2*sqrt(pi))
+		data_out(11) = INPUT_T(0.45704579946446572)*y*(INPUT_T(1.0) - INPUT_T(5.0)*z2);                                // sqrt(42)*y*(1 - 5*z2)/(8*sqrt(pi))
+		data_out(12) = INPUT_T(0.3731763325901154)*z*(INPUT_T(5.0)*z2 - INPUT_T(3.0));                         // sqrt(7)*z*(5*z2 - 3)/(4*sqrt(pi))
+		data_out(13) = INPUT_T(0.45704579946446572)*x*(INPUT_T(1.0) - INPUT_T(5.0)*z2);                                // sqrt(42)*x*(1 - 5*z2)/(8*sqrt(pi))
+		data_out(14) = INPUT_T(1.4453057213202769)*z*(x2 - y2);                              // sqrt(105)*z*(x2 - y2)/(4*sqrt(pi))
+		data_out(15) = INPUT_T(0.59004358992664352)*x*(-x2 + INPUT_T(3.0)*y2);                                // sqrt(70)*x*(-x2 + 3*y2)/(8*sqrt(pi))
 		if (degree <= 4) { return; }
-		data_out(16) = 2.5033429417967046f*xy*(x2 - y2);                             // 3*sqrt(35)*xy*(x2 - y2)/(4*sqrt(pi))
-		data_out(17) = 1.7701307697799304f*yz*(-3.0f*x2 + y2);                                // 3*sqrt(70)*yz*(-3*x2 + y2)/(8*sqrt(pi))
-		data_out(18) = 0.94617469575756008f*xy*(7.0f*z2 - 1.0f);                               // 3*sqrt(5)*xy*(7*z2 - 1)/(4*sqrt(pi))
-		data_out(19) = 0.66904654355728921f*yz*(3.0f - 7.0f*z2);                               // 3*sqrt(10)*yz*(3 - 7*z2)/(8*sqrt(pi))
-		data_out(20) = -3.1735664074561294f*z2 + 3.7024941420321507f*z4 + 0.31735664074561293f;                                // 3*(-30*z2 + 35*z4 + 3)/(16*sqrt(pi))
-		data_out(21) = 0.66904654355728921f*xz*(3.0f - 7.0f*z2);                               // 3*sqrt(10)*xz*(3 - 7*z2)/(8*sqrt(pi))
-		data_out(22) = 0.47308734787878004f*(x2 - y2)*(7.0f*z2 - 1.0f);                                // 3*sqrt(5)*(x2 - y2)*(7*z2 - 1)/(8*sqrt(pi))
-		data_out(23) = 1.7701307697799304f*xz*(-x2 + 3.0f*y2);                                // 3*sqrt(70)*xz*(-x2 + 3*y2)/(8*sqrt(pi))
-		data_out(24) = -3.7550144126950569f*x2*y2 + 0.62583573544917614f*x4 + 0.62583573544917614f*y4;                         // 3*sqrt(35)*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
+		data_out(16) = INPUT_T(2.5033429417967046)*xy*(x2 - y2);                             // 3*sqrt(35)*xy*(x2 - y2)/(4*sqrt(pi))
+		data_out(17) = INPUT_T(1.7701307697799304)*yz*(-INPUT_T(3.0)*x2 + y2);                                // 3*sqrt(70)*yz*(-3*x2 + y2)/(8*sqrt(pi))
+		data_out(18) = INPUT_T(0.94617469575756008)*xy*(INPUT_T(7.0)*z2 - INPUT_T(1.0));                               // 3*sqrt(5)*xy*(7*z2 - 1)/(4*sqrt(pi))
+		data_out(19) = INPUT_T(0.66904654355728921)*yz*(INPUT_T(3.0) - INPUT_T(7.0)*z2);                               // 3*sqrt(10)*yz*(3 - 7*z2)/(8*sqrt(pi))
+		data_out(20) = -INPUT_T(3.1735664074561294)*z2 + INPUT_T(3.7024941420321507)*z4 + INPUT_T(0.31735664074561293);                                // 3*(-30*z2 + 35*z4 + 3)/(16*sqrt(pi))
+		data_out(21) = INPUT_T(0.66904654355728921)*xz*(INPUT_T(3.0) - INPUT_T(7.0)*z2);                               // 3*sqrt(10)*xz*(3 - 7*z2)/(8*sqrt(pi))
+		data_out(22) = INPUT_T(0.47308734787878004)*(x2 - y2)*(INPUT_T(7.0)*z2 - INPUT_T(1.0));                                // 3*sqrt(5)*(x2 - y2)*(7*z2 - 1)/(8*sqrt(pi))
+		data_out(23) = INPUT_T(1.7701307697799304)*xz*(-x2 + INPUT_T(3.0)*y2);                                // 3*sqrt(70)*xz*(-x2 + 3*y2)/(8*sqrt(pi))
+		data_out(24) = -INPUT_T(3.7550144126950569)*x2*y2 + INPUT_T(0.62583573544917614)*x4 + INPUT_T(0.62583573544917614)*y4;                         // 3*sqrt(35)*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
 		if (degree <= 5) { return; }
-		data_out(25) = 0.65638205684017015f*y*(10.0f*x2*y2 - 5.0f*x4 - y4);                            // 3*sqrt(154)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		data_out(26) = 8.3026492595241645f*xy*z*(x2 - y2);                           // 3*sqrt(385)*xy*z*(x2 - y2)/(4*sqrt(pi))
-		data_out(27) = -0.48923829943525038f*y*(3.0f*x2 - y2)*(9.0f*z2 - 1.0f);                         // -sqrt(770)*y*(3*x2 - y2)*(9*z2 - 1)/(32*sqrt(pi))
-		data_out(28) = 4.7935367849733241f*xy*z*(3.0f*z2 - 1.0f);                              // sqrt(1155)*xy*z*(3*z2 - 1)/(4*sqrt(pi))
-		data_out(29) = 0.45294665119569694f*y*(14.0f*z2 - 21.0f*z4 - 1.0f);                             // sqrt(165)*y*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
-		data_out(30) = 0.1169503224534236f*z*(-70.0f*z2 + 63.0f*z4 + 15.0f);                            // sqrt(11)*z*(-70*z2 + 63*z4 + 15)/(16*sqrt(pi))
-		data_out(31) = 0.45294665119569694f*x*(14.0f*z2 - 21.0f*z4 - 1.0f);                             // sqrt(165)*x*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
-		data_out(32) = 2.3967683924866621f*z*(x2 - y2)*(3.0f*z2 - 1.0f);                               // sqrt(1155)*z*(x2 - y2)*(3*z2 - 1)/(8*sqrt(pi))
-		data_out(33) = -0.48923829943525038f*x*(x2 - 3.0f*y2)*(9.0f*z2 - 1.0f);                         // -sqrt(770)*x*(x2 - 3*y2)*(9*z2 - 1)/(32*sqrt(pi))
-		data_out(34) = 2.0756623148810411f*z*(-6.0f*x2*y2 + x4 + y4);                         // 3*sqrt(385)*z*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
-		data_out(35) = 0.65638205684017015f*x*(10.0f*x2*y2 - x4 - 5.0f*y4);                            // 3*sqrt(154)*x*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
+		data_out(25) = INPUT_T(0.65638205684017015)*y*(INPUT_T(10.0)*x2*y2 - INPUT_T(5.0)*x4 - y4);                            // 3*sqrt(154)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		data_out(26) = INPUT_T(8.3026492595241645)*xy*z*(x2 - y2);                           // 3*sqrt(385)*xy*z*(x2 - y2)/(4*sqrt(pi))
+		data_out(27) = -INPUT_T(0.48923829943525038)*y*(INPUT_T(3.0)*x2 - y2)*(INPUT_T(9.0)*z2 - INPUT_T(1.0));                         // -sqrt(770)*y*(3*x2 - y2)*(9*z2 - 1)/(32*sqrt(pi))
+		data_out(28) = INPUT_T(4.7935367849733241)*xy*z*(INPUT_T(3.0)*z2 - INPUT_T(1.0));                              // sqrt(1155)*xy*z*(3*z2 - 1)/(4*sqrt(pi))
+		data_out(29) = INPUT_T(0.45294665119569694)*y*(INPUT_T(14.0)*z2 - INPUT_T(21.0)*z4 - INPUT_T(1.0));                             // sqrt(165)*y*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
+		data_out(30) = INPUT_T(0.1169503224534236)*z*(-INPUT_T(70.0)*z2 + INPUT_T(63.0)*z4 + INPUT_T(15.0));                            // sqrt(11)*z*(-70*z2 + 63*z4 + 15)/(16*sqrt(pi))
+		data_out(31) = INPUT_T(0.45294665119569694)*x*(INPUT_T(14.0)*z2 - INPUT_T(21.0)*z4 - INPUT_T(1.0));                             // sqrt(165)*x*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
+		data_out(32) = INPUT_T(2.3967683924866621)*z*(x2 - y2)*(INPUT_T(3.0)*z2 - INPUT_T(1.0));                               // sqrt(1155)*z*(x2 - y2)*(3*z2 - 1)/(8*sqrt(pi))
+		data_out(33) = -INPUT_T(0.48923829943525038)*x*(x2 - INPUT_T(3.0)*y2)*(INPUT_T(9.0)*z2 - INPUT_T(1.0));                         // -sqrt(770)*x*(x2 - 3*y2)*(9*z2 - 1)/(32*sqrt(pi))
+		data_out(34) = INPUT_T(2.0756623148810411)*z*(-INPUT_T(6.0)*x2*y2 + x4 + y4);                         // 3*sqrt(385)*z*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
+		data_out(35) = INPUT_T(0.65638205684017015)*x*(INPUT_T(10.0)*x2*y2 - x4 - INPUT_T(5.0)*y4);                            // 3*sqrt(154)*x*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
 		if (degree <= 6) { return; }
-		data_out(36) = 1.3663682103838286f*xy*(-10.0f*x2*y2 + 3.0f*x4 + 3.0f*y4);                               // sqrt(6006)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
-		data_out(37) = 2.3666191622317521f*yz*(10.0f*x2*y2 - 5.0f*x4 - y4);                            // 3*sqrt(2002)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		data_out(38) = 2.0182596029148963f*xy*(x2 - y2)*(11.0f*z2 - 1.0f);                             // 3*sqrt(91)*xy*(x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
-		data_out(39) = -0.92120525951492349f*yz*(3.0f*x2 - y2)*(11.0f*z2 - 3.0f);                               // -sqrt(2730)*yz*(3*x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
-		data_out(40) = 0.92120525951492349f*xy*(-18.0f*z2 + 33.0f*z4 + 1.0f);                           // sqrt(2730)*xy*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
-		data_out(41) = 0.58262136251873131f*yz*(30.0f*z2 - 33.0f*z4 - 5.0f);                            // sqrt(273)*yz*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
-		data_out(42) = 6.6747662381009842f*z2 - 20.024298714302954f*z4 + 14.684485723822165f*z6 - 0.31784601133814211f;                         // sqrt(13)*(105*z2 - 315*z4 + 231*z6 - 5)/(32*sqrt(pi))
-		data_out(43) = 0.58262136251873131f*xz*(30.0f*z2 - 33.0f*z4 - 5.0f);                            // sqrt(273)*xz*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
-		data_out(44) = 0.46060262975746175f*(x2 - y2)*(11.0f*z2*(3.0f*z2 - 1.0f) - 7.0f*z2 + 1.0f);                               // sqrt(2730)*(x2 - y2)*(11*z2*(3*z2 - 1) - 7*z2 + 1)/(64*sqrt(pi))
-		data_out(45) = -0.92120525951492349f*xz*(x2 - 3.0f*y2)*(11.0f*z2 - 3.0f);                               // -sqrt(2730)*xz*(x2 - 3*y2)*(11*z2 - 3)/(32*sqrt(pi))
-		data_out(46) = 0.50456490072872406f*(11.0f*z2 - 1.0f)*(-6.0f*x2*y2 + x4 + y4);                          // 3*sqrt(91)*(11*z2 - 1)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
-		data_out(47) = 2.3666191622317521f*xz*(10.0f*x2*y2 - x4 - 5.0f*y4);                            // 3*sqrt(2002)*xz*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
-		data_out(48) = 10.247761577878714f*x2*y4 - 10.247761577878714f*x4*y2 + 0.6831841051919143f*x6 - 0.6831841051919143f*y6;                         // sqrt(6006)*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
+		data_out(36) = INPUT_T(1.3663682103838286)*xy*(-INPUT_T(10.0)*x2*y2 + INPUT_T(3.0)*x4 + INPUT_T(3.0)*y4);                               // sqrt(6006)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
+		data_out(37) = INPUT_T(2.3666191622317521)*yz*(INPUT_T(10.0)*x2*y2 - INPUT_T(5.0)*x4 - y4);                            // 3*sqrt(2002)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		data_out(38) = INPUT_T(2.0182596029148963)*xy*(x2 - y2)*(INPUT_T(11.0)*z2 - INPUT_T(1.0));                             // 3*sqrt(91)*xy*(x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
+		data_out(39) = -INPUT_T(0.92120525951492349)*yz*(INPUT_T(3.0)*x2 - y2)*(INPUT_T(11.0)*z2 - INPUT_T(3.0));                               // -sqrt(2730)*yz*(3*x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
+		data_out(40) = INPUT_T(0.92120525951492349)*xy*(-INPUT_T(18.0)*z2 + INPUT_T(33.0)*z4 + INPUT_T(1.0));                           // sqrt(2730)*xy*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
+		data_out(41) = INPUT_T(0.58262136251873131)*yz*(INPUT_T(30.0)*z2 - INPUT_T(33.0)*z4 - INPUT_T(5.0));                            // sqrt(273)*yz*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
+		data_out(42) = INPUT_T(6.6747662381009842)*z2 - INPUT_T(20.024298714302954)*z4 + INPUT_T(14.684485723822165)*z6 - INPUT_T(0.31784601133814211);                         // sqrt(13)*(105*z2 - 315*z4 + 231*z6 - 5)/(32*sqrt(pi))
+		data_out(43) = INPUT_T(0.58262136251873131)*xz*(INPUT_T(30.0)*z2 - INPUT_T(33.0)*z4 - INPUT_T(5.0));                            // sqrt(273)*xz*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
+		data_out(44) = INPUT_T(0.46060262975746175)*(x2 - y2)*(INPUT_T(11.0)*z2*(INPUT_T(3.0)*z2 - INPUT_T(1.0)) - INPUT_T(7.0)*z2 + INPUT_T(1.0));                               // sqrt(2730)*(x2 - y2)*(11*z2*(3*z2 - 1) - 7*z2 + 1)/(64*sqrt(pi))
+		data_out(45) = -INPUT_T(0.92120525951492349)*xz*(x2 - INPUT_T(3.0)*y2)*(INPUT_T(11.0)*z2 - INPUT_T(3.0));                               // -sqrt(2730)*xz*(x2 - 3*y2)*(11*z2 - 3)/(32*sqrt(pi))
+		data_out(46) = INPUT_T(0.50456490072872406)*(INPUT_T(11.0)*z2 - INPUT_T(1.0))*(-INPUT_T(6.0)*x2*y2 + x4 + y4);                          // 3*sqrt(91)*(11*z2 - 1)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
+		data_out(47) = INPUT_T(2.3666191622317521)*xz*(INPUT_T(10.0)*x2*y2 - x4 - INPUT_T(5.0)*y4);                            // 3*sqrt(2002)*xz*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
+		data_out(48) = INPUT_T(10.247761577878714)*x2*y4 - INPUT_T(10.247761577878714)*x4*y2 + INPUT_T(0.6831841051919143)*x6 - INPUT_T(0.6831841051919143)*y6;                         // sqrt(6006)*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
 		if (degree <= 7) { return; }
-		data_out(49) = 0.70716273252459627f*y*(-21.0f*x2*y4 + 35.0f*x4*y2 - 7.0f*x6 + y6);                              // 3*sqrt(715)*y*(-21*x2*y4 + 35*x4*y2 - 7*x6 + y6)/(64*sqrt(pi))
-		data_out(50) = 5.2919213236038001f*xy*z*(-10.0f*x2*y2 + 3.0f*x4 + 3.0f*y4);                             // 3*sqrt(10010)*xy*z*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
-		data_out(51) = -0.51891557872026028f*y*(13.0f*z2 - 1.0f)*(-10.0f*x2*y2 + 5.0f*x4 + y4);                          // -3*sqrt(385)*y*(13*z2 - 1)*(-10*x2*y2 + 5*x4 + y4)/(64*sqrt(pi))
-		data_out(52) = 4.1513246297620823f*xy*z*(x2 - y2)*(13.0f*z2 - 3.0f);                           // 3*sqrt(385)*xy*z*(x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
-		data_out(53) = -0.15645893386229404f*y*(3.0f*x2 - y2)*(13.0f*z2*(11.0f*z2 - 3.0f) - 27.0f*z2 + 3.0f);                              // -3*sqrt(35)*y*(3*x2 - y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
-		data_out(54) = 0.44253269244498261f*xy*z*(-110.0f*z2 + 143.0f*z4 + 15.0f);                              // 3*sqrt(70)*xy*z*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
-		data_out(55) = 0.090331607582517306f*y*(-135.0f*z2 + 495.0f*z4 - 429.0f*z6 + 5.0f);                              // sqrt(105)*y*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
-		data_out(56) = 0.068284276912004949f*z*(315.0f*z2 - 693.0f*z4 + 429.0f*z6 - 35.0f);                              // sqrt(15)*z*(315*z2 - 693*z4 + 429*z6 - 35)/(32*sqrt(pi))
-		data_out(57) = 0.090331607582517306f*x*(-135.0f*z2 + 495.0f*z4 - 429.0f*z6 + 5.0f);                              // sqrt(105)*x*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
-		data_out(58) = 0.07375544874083044f*z*(x2 - y2)*(143.0f*z2*(3.0f*z2 - 1.0f) - 187.0f*z2 + 45.0f);                         // sqrt(70)*z*(x2 - y2)*(143*z2*(3*z2 - 1) - 187*z2 + 45)/(64*sqrt(pi))
-		data_out(59) = -0.15645893386229404f*x*(x2 - 3.0f*y2)*(13.0f*z2*(11.0f*z2 - 3.0f) - 27.0f*z2 + 3.0f);                              // -3*sqrt(35)*x*(x2 - 3*y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
-		data_out(60) = 1.0378311574405206f*z*(13.0f*z2 - 3.0f)*(-6.0f*x2*y2 + x4 + y4);                         // 3*sqrt(385)*z*(13*z2 - 3)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
-		data_out(61) = -0.51891557872026028f*x*(13.0f*z2 - 1.0f)*(-10.0f*x2*y2 + x4 + 5.0f*y4);                          // -3*sqrt(385)*x*(13*z2 - 1)*(-10*x2*y2 + x4 + 5*y4)/(64*sqrt(pi))
-		data_out(62) = 2.6459606618019f*z*(15.0f*x2*y4 - 15.0f*x4*y2 + x6 - y6);                               // 3*sqrt(10010)*z*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
-		data_out(63) = 0.70716273252459627f*x*(-35.0f*x2*y4 + 21.0f*x4*y2 - x6 + 7.0f*y6);                              // 3*sqrt(715)*x*(-35*x2*y4 + 21*x4*y2 - x6 + 7*y6)/(64*sqrt(pi))
+		data_out(49) = INPUT_T(0.70716273252459627)*y*(-INPUT_T(21.0)*x2*y4 + INPUT_T(35.0)*x4*y2 - INPUT_T(7.0)*x6 + y6);                              // 3*sqrt(715)*y*(-21*x2*y4 + 35*x4*y2 - 7*x6 + y6)/(64*sqrt(pi))
+		data_out(50) = INPUT_T(5.2919213236038001)*xy*z*(-INPUT_T(10.0)*x2*y2 + INPUT_T(3.0)*x4 + INPUT_T(3.0)*y4);                             // 3*sqrt(10010)*xy*z*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
+		data_out(51) = -INPUT_T(0.51891557872026028)*y*(INPUT_T(13.0)*z2 - INPUT_T(1.0))*(-INPUT_T(10.0)*x2*y2 + INPUT_T(5.0)*x4 + y4);                          // -3*sqrt(385)*y*(13*z2 - 1)*(-10*x2*y2 + 5*x4 + y4)/(64*sqrt(pi))
+		data_out(52) = INPUT_T(4.1513246297620823)*xy*z*(x2 - y2)*(INPUT_T(13.0)*z2 - INPUT_T(3.0));                           // 3*sqrt(385)*xy*z*(x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
+		data_out(53) = -INPUT_T(0.15645893386229404)*y*(INPUT_T(3.0)*x2 - y2)*(INPUT_T(13.0)*z2*(INPUT_T(11.0)*z2 - INPUT_T(3.0)) - INPUT_T(27.0)*z2 + INPUT_T(3.0));                              // -3*sqrt(35)*y*(3*x2 - y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
+		data_out(54) = INPUT_T(0.44253269244498261)*xy*z*(-INPUT_T(110.0)*z2 + INPUT_T(143.0)*z4 + INPUT_T(15.0));                              // 3*sqrt(70)*xy*z*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
+		data_out(55) = INPUT_T(0.090331607582517306)*y*(-INPUT_T(135.0)*z2 + INPUT_T(495.0)*z4 - INPUT_T(429.0)*z6 + INPUT_T(5.0));                              // sqrt(105)*y*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
+		data_out(56) = INPUT_T(0.068284276912004949)*z*(INPUT_T(315.0)*z2 - INPUT_T(693.0)*z4 + INPUT_T(429.0)*z6 - INPUT_T(35.0));                              // sqrt(15)*z*(315*z2 - 693*z4 + 429*z6 - 35)/(32*sqrt(pi))
+		data_out(57) = INPUT_T(0.090331607582517306)*x*(-INPUT_T(135.0)*z2 + INPUT_T(495.0)*z4 - INPUT_T(429.0)*z6 + INPUT_T(5.0));                              // sqrt(105)*x*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
+		data_out(58) = INPUT_T(0.07375544874083044)*z*(x2 - y2)*(INPUT_T(143.0)*z2*(INPUT_T(3.0)*z2 - INPUT_T(1.0)) - INPUT_T(187.0)*z2 + INPUT_T(45.0));                         // sqrt(70)*z*(x2 - y2)*(143*z2*(3*z2 - 1) - 187*z2 + 45)/(64*sqrt(pi))
+		data_out(59) = -INPUT_T(0.15645893386229404)*x*(x2 - INPUT_T(3.0)*y2)*(INPUT_T(13.0)*z2*(INPUT_T(11.0)*z2 - INPUT_T(3.0)) - INPUT_T(27.0)*z2 + INPUT_T(3.0));                              // -3*sqrt(35)*x*(x2 - 3*y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
+		data_out(60) = INPUT_T(1.0378311574405206)*z*(INPUT_T(13.0)*z2 - INPUT_T(3.0))*(-INPUT_T(6.0)*x2*y2 + x4 + y4);                         // 3*sqrt(385)*z*(13*z2 - 3)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
+		data_out(61) = -INPUT_T(0.51891557872026028)*x*(INPUT_T(13.0)*z2 - INPUT_T(1.0))*(-INPUT_T(10.0)*x2*y2 + x4 + INPUT_T(5.0)*y4);                          // -3*sqrt(385)*x*(13*z2 - 1)*(-10*x2*y2 + x4 + 5*y4)/(64*sqrt(pi))
+		data_out(62) = INPUT_T(2.6459606618019)*z*(INPUT_T(15.0)*x2*y4 - INPUT_T(15.0)*x4*y2 + x6 - y6);                               // 3*sqrt(10010)*z*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
+		data_out(63) = INPUT_T(0.70716273252459627)*x*(-INPUT_T(35.0)*x2*y4 + INPUT_T(21.0)*x4*y2 - x6 + INPUT_T(7.0)*y6);                              // 3*sqrt(715)*x*(-35*x2*y4 + 21*x4*y2 - x6 + 7*y6)/(64*sqrt(pi))
 	};
 
 	write_sh();
 }
 
-template <typename T>
+template <typename T, typename INPUT_T>
 __global__ void kernel_sh_backward(
 	const uint32_t num_elements,
 	const uint32_t degree,
 	const uint32_t num_to_pad,
 	MatrixView<const T> dL_dy,
-	MatrixView<const float> data_in,
-	MatrixView<float> dL_dx
+	MatrixView<const INPUT_T> data_in,
+	MatrixView<INPUT_T> dL_dx
 ) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= num_elements) return;
 
 	dL_dy.advance(num_to_pad, i);
 
-	float x = data_in(0, i) * 2.f - 1.f;
-	float y = data_in(1, i) * 2.f - 1.f;
-	float z = data_in(2, i) * 2.f - 1.f;
+	INPUT_T x = data_in(0, i) * INPUT_T(2) - INPUT_T(1);
+	INPUT_T y = data_in(1, i) * INPUT_T(2) - INPUT_T(1);
+	INPUT_T z = data_in(2, i) * INPUT_T(2) - INPUT_T(1);
 
 	// Let compiler figure out how to sequence/reorder these calculations w.r.t. branches
-	float xy=x*y, xz=x*z, yz=y*z, x2=x*x, y2=y*y, z2=z*z;
-	float x4=x2*x2, y4=y2*y2, z4=z2*z2;
-	float x6=x4*x2, y6=y4*y2, z6=z4*z2;
+	INPUT_T xy=x*y, xz=x*z, yz=y*z, x2=x*x, y2=y*y, z2=z*z;
+	INPUT_T x4=x2*x2, y4=y2*y2, z4=z2*z2;
+	INPUT_T x6=x4*x2, y6=y4*y2, z6=z4*z2;
 
-	float dx = 0.0f;
-	float dy = 0.0f;
-	float dz = 0.0f;
+	INPUT_T dx = 0.0f;
+	INPUT_T dy = 0.0f;
+	INPUT_T dz = 0.0f;
 
 	auto compute_grad = [&]() {
-		// dx += (float)dL_dy(0) * (0);                                // 0
-		// dy += (float)dL_dy(0) * (0);                                // 0
-		// dz += (float)dL_dy(0) * (0);                                // 0
+		// dx += (INPUT_T)dL_dy(0) * (0);                                // 0
+		// dy += (INPUT_T)dL_dy(0) * (0);                                // 0
+		// dz += (INPUT_T)dL_dy(0) * (0);                                // 0
 		if (degree <= 1) { return; }
-		// dx += (float)dL_dy(1) * (0);                                // 0
-		dy += (float)dL_dy(1) * (-0.48860251190291992);                                // -sqrt(3)/(2*sqrt(pi))
-		// dz += (float)dL_dy(1) * (0);                                // 0
-		// dx += (float)dL_dy(2) * (0);                                // 0
-		// dy += (float)dL_dy(2) * (0);                                // 0
-		dz += (float)dL_dy(2) * (0.48860251190291992);                         // sqrt(3)/(2*sqrt(pi))
-		dx += (float)dL_dy(3) * (-0.48860251190291992);                                // -sqrt(3)/(2*sqrt(pi))
-		// dy += (float)dL_dy(3) * (0);                                // 0
-		// dz += (float)dL_dy(3) * (0);                                // 0
+		// dx += (INPUT_T)dL_dy(1) * (0);                                // 0
+		dy += (INPUT_T)dL_dy(1) * (INPUT_T(-0.48860251190291992));                                // -sqrt(3)/(2*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(1) * (0);                                // 0
+		// dx += (INPUT_T)dL_dy(2) * (0);                                // 0
+		// dy += (INPUT_T)dL_dy(2) * (0);                                // 0
+		dz += (INPUT_T)dL_dy(2) * (INPUT_T(0.48860251190291992));                         // sqrt(3)/(2*sqrt(pi))
+		dx += (INPUT_T)dL_dy(3) * (INPUT_T(-0.48860251190291992));                                // -sqrt(3)/(2*sqrt(pi))
+		// dy += (INPUT_T)dL_dy(3) * (0);                                // 0
+		// dz += (INPUT_T)dL_dy(3) * (0);                                // 0
 		if (degree <= 2) { return; }
-		dx += (float)dL_dy(4) * (1.0925484305920792*y);                                // sqrt(15)*y/(2*sqrt(pi))
-		dy += (float)dL_dy(4) * (1.0925484305920792*x);                                // sqrt(15)*x/(2*sqrt(pi))
-		// dz += (float)dL_dy(4) * (0);                                // 0
-		// dx += (float)dL_dy(5) * (0);                                // 0
-		dy += (float)dL_dy(5) * (-1.0925484305920792*z);                               // -sqrt(15)*z/(2*sqrt(pi))
-		dz += (float)dL_dy(5) * (-1.0925484305920792*y);                               // -sqrt(15)*y/(2*sqrt(pi))
-		// dx += (float)dL_dy(6) * (0);                                // 0
-		// dy += (float)dL_dy(6) * (0);                                // 0
-		dz += (float)dL_dy(6) * (1.8923493915151202*z);                                // 3*sqrt(5)*z/(2*sqrt(pi))
-		dx += (float)dL_dy(7) * (-1.0925484305920792*z);                               // -sqrt(15)*z/(2*sqrt(pi))
-		// dy += (float)dL_dy(7) * (0);                                // 0
-		dz += (float)dL_dy(7) * (-1.0925484305920792*x);                               // -sqrt(15)*x/(2*sqrt(pi))
-		dx += (float)dL_dy(8) * (1.0925484305920792*x);                                // sqrt(15)*x/(2*sqrt(pi))
-		dy += (float)dL_dy(8) * (-1.0925484305920792*y);                               // -sqrt(15)*y/(2*sqrt(pi))
-		// dz += (float)dL_dy(8) * (0);                                // 0
+		dx += (INPUT_T)dL_dy(4) * (INPUT_T(1.0925484305920792)*y);                                // sqrt(15)*y/(2*sqrt(pi))
+		dy += (INPUT_T)dL_dy(4) * (INPUT_T(1.0925484305920792)*x);                                // sqrt(15)*x/(2*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(4) * (0);                                // 0
+		// dx += (INPUT_T)dL_dy(5) * (0);                                // 0
+		dy += (INPUT_T)dL_dy(5) * (INPUT_T(-1.0925484305920792)*z);                               // -sqrt(15)*z/(2*sqrt(pi))
+		dz += (INPUT_T)dL_dy(5) * (INPUT_T(-1.0925484305920792)*y);                               // -sqrt(15)*y/(2*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(6) * (0);                                // 0
+		// dy += (INPUT_T)dL_dy(6) * (0);                                // 0
+		dz += (INPUT_T)dL_dy(6) * (INPUT_T(1.8923493915151202)*z);                                // 3*sqrt(5)*z/(2*sqrt(pi))
+		dx += (INPUT_T)dL_dy(7) * (INPUT_T(-1.0925484305920792)*z);                               // -sqrt(15)*z/(2*sqrt(pi))
+		// dy += (INPUT_T)dL_dy(7) * (0);                                // 0
+		dz += (INPUT_T)dL_dy(7) * (INPUT_T(-1.0925484305920792)*x);                               // -sqrt(15)*x/(2*sqrt(pi))
+		dx += (INPUT_T)dL_dy(8) * (INPUT_T(1.0925484305920792)*x);                                // sqrt(15)*x/(2*sqrt(pi))
+		dy += (INPUT_T)dL_dy(8) * (INPUT_T(-1.0925484305920792)*y);                               // -sqrt(15)*y/(2*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(8) * (0);                                // 0
 		if (degree <= 3) { return; }
-		dx += (float)dL_dy(9) * (-3.5402615395598609*xy);                              // -3*sqrt(70)*xy/(4*sqrt(pi))
-		dy += (float)dL_dy(9) * (-1.7701307697799304*x2 + 1.7701307697799304*y2);                              // 3*sqrt(70)*(-x2 + y2)/(8*sqrt(pi))
-		// dz += (float)dL_dy(9) * (0);                                // 0
-		dx += (float)dL_dy(10) * (2.8906114426405538*yz);                              // sqrt(105)*yz/(2*sqrt(pi))
-		dy += (float)dL_dy(10) * (2.8906114426405538*xz);                              // sqrt(105)*xz/(2*sqrt(pi))
-		dz += (float)dL_dy(10) * (2.8906114426405538*xy);                              // sqrt(105)*xy/(2*sqrt(pi))
-		// dx += (float)dL_dy(11) * (0);                               // 0
-		dy += (float)dL_dy(11) * (0.45704579946446572 - 2.2852289973223288*z2);                                // sqrt(42)*(1 - 5*z2)/(8*sqrt(pi))
-		dz += (float)dL_dy(11) * (-4.5704579946446566*yz);                             // -5*sqrt(42)*yz/(4*sqrt(pi))
-		// dx += (float)dL_dy(12) * (0);                               // 0
-		// dy += (float)dL_dy(12) * (0);                               // 0
-		dz += (float)dL_dy(12) * (5.597644988851731*z2 - 1.1195289977703462);                          // 3*sqrt(7)*(5*z2 - 1)/(4*sqrt(pi))
-		dx += (float)dL_dy(13) * (0.45704579946446572 - 2.2852289973223288*z2);                                // sqrt(42)*(1 - 5*z2)/(8*sqrt(pi))
-		// dy += (float)dL_dy(13) * (0);                               // 0
-		dz += (float)dL_dy(13) * (-4.5704579946446566*xz);                             // -5*sqrt(42)*xz/(4*sqrt(pi))
-		dx += (float)dL_dy(14) * (2.8906114426405538*xz);                              // sqrt(105)*xz/(2*sqrt(pi))
-		dy += (float)dL_dy(14) * (-2.8906114426405538*yz);                             // -sqrt(105)*yz/(2*sqrt(pi))
-		dz += (float)dL_dy(14) * (1.4453057213202769*x2 - 1.4453057213202769*y2);                              // sqrt(105)*(x2 - y2)/(4*sqrt(pi))
-		dx += (float)dL_dy(15) * (-1.7701307697799304*x2 + 1.7701307697799304*y2);                             // 3*sqrt(70)*(-x2 + y2)/(8*sqrt(pi))
-		dy += (float)dL_dy(15) * (3.5402615395598609*xy);                              // 3*sqrt(70)*xy/(4*sqrt(pi))
-		// dz += (float)dL_dy(15) * (0);                               // 0
+		dx += (INPUT_T)dL_dy(9) * (INPUT_T(-3.5402615395598609)*xy);                              // -3*sqrt(70)*xy/(4*sqrt(pi))
+		dy += (INPUT_T)dL_dy(9) * (INPUT_T(-1.7701307697799304)*x2 + INPUT_T(1.7701307697799304)*y2);                              // 3*sqrt(70)*(-x2 + y2)/(8*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(9) * (0);                                // 0
+		dx += (INPUT_T)dL_dy(10) * (INPUT_T(2.8906114426405538)*yz);                              // sqrt(105)*yz/(2*sqrt(pi))
+		dy += (INPUT_T)dL_dy(10) * (INPUT_T(2.8906114426405538)*xz);                              // sqrt(105)*xz/(2*sqrt(pi))
+		dz += (INPUT_T)dL_dy(10) * (INPUT_T(2.8906114426405538)*xy);                              // sqrt(105)*xy/(2*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(11) * (0);                               // 0
+		dy += (INPUT_T)dL_dy(11) * (INPUT_T(0.45704579946446572) - INPUT_T(2.2852289973223288)*z2);                                // sqrt(42)*(1 - 5*z2)/(8*sqrt(pi))
+		dz += (INPUT_T)dL_dy(11) * (INPUT_T(-4.5704579946446566)*yz);                             // -5*sqrt(42)*yz/(4*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(12) * (0);                               // 0
+		// dy += (INPUT_T)dL_dy(12) * (0);                               // 0
+		dz += (INPUT_T)dL_dy(12) * (INPUT_T(5.597644988851731)*z2 - INPUT_T(1.1195289977703462));                          // 3*sqrt(7)*(5*z2 - 1)/(4*sqrt(pi))
+		dx += (INPUT_T)dL_dy(13) * (INPUT_T(0.45704579946446572) - INPUT_T(2.2852289973223288)*z2);                                // sqrt(42)*(1 - 5*z2)/(8*sqrt(pi))
+		// dy += (INPUT_T)dL_dy(13) * (0);                               // 0
+		dz += (INPUT_T)dL_dy(13) * (INPUT_T(-4.5704579946446566)*xz);                             // -5*sqrt(42)*xz/(4*sqrt(pi))
+		dx += (INPUT_T)dL_dy(14) * (INPUT_T(2.8906114426405538)*xz);                              // sqrt(105)*xz/(2*sqrt(pi))
+		dy += (INPUT_T)dL_dy(14) * (INPUT_T(-2.8906114426405538)*yz);                             // -sqrt(105)*yz/(2*sqrt(pi))
+		dz += (INPUT_T)dL_dy(14) * (INPUT_T(1.4453057213202769)*x2 - INPUT_T(1.4453057213202769)*y2);                              // sqrt(105)*(x2 - y2)/(4*sqrt(pi))
+		dx += (INPUT_T)dL_dy(15) * (INPUT_T(-1.7701307697799304)*x2 + INPUT_T(1.7701307697799304)*y2);                             // 3*sqrt(70)*(-x2 + y2)/(8*sqrt(pi))
+		dy += (INPUT_T)dL_dy(15) * (INPUT_T(3.5402615395598609)*xy);                              // 3*sqrt(70)*xy/(4*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(15) * (0);                               // 0
 		if (degree <= 4) { return; }
-		dx += (float)dL_dy(16) * (2.5033429417967046*y*(3.0*x2 - y2));                         // 3*sqrt(35)*y*(3*x2 - y2)/(4*sqrt(pi))
-		dy += (float)dL_dy(16) * (2.5033429417967046*x*(x2 - 3.0*y2));                         // 3*sqrt(35)*x*(x2 - 3*y2)/(4*sqrt(pi))
-		// dz += (float)dL_dy(16) * (0);                               // 0
-		dx += (float)dL_dy(17) * (-10.620784618679583*xy*z);                           // -9*sqrt(70)*xy*z/(4*sqrt(pi))
-		dy += (float)dL_dy(17) * (5.3103923093397913*z*(-x2 + y2));                            // 9*sqrt(70)*z*(-x2 + y2)/(8*sqrt(pi))
-		dz += (float)dL_dy(17) * (1.7701307697799304*y*(-3.0*x2 + y2));                                // 3*sqrt(70)*y*(-3*x2 + y2)/(8*sqrt(pi))
-		dx += (float)dL_dy(18) * (0.94617469575756008*y*(7.0*z2 - 1.0));                               // 3*sqrt(5)*y*(7*z2 - 1)/(4*sqrt(pi))
-		dy += (float)dL_dy(18) * (0.94617469575756008*x*(7.0*z2 - 1.0));                               // 3*sqrt(5)*x*(7*z2 - 1)/(4*sqrt(pi))
-		dz += (float)dL_dy(18) * (13.246445740605839*xy*z);                            // 21*sqrt(5)*xy*z/(2*sqrt(pi))
-		// dx += (float)dL_dy(19) * (0);                               // 0
-		dy += (float)dL_dy(19) * (0.66904654355728921*z*(3.0 - 7.0*z2));                               // 3*sqrt(10)*z*(3 - 7*z2)/(8*sqrt(pi))
-		dz += (float)dL_dy(19) * (2.0071396306718676*y*(1.0 - 7.0*z2));                                // 9*sqrt(10)*y*(1 - 7*z2)/(8*sqrt(pi))
-		// dx += (float)dL_dy(20) * (0);                               // 0
-		// dy += (float)dL_dy(20) * (0);                               // 0
-		dz += (float)dL_dy(20) * (14.809976568128603*pow(z, 3) - 6.3471328149122579*z);                                // (105*z**3 - 45*z)/(4*sqrt(pi))
-		dx += (float)dL_dy(21) * (0.66904654355728921*z*(3.0 - 7.0*z2));                               // 3*sqrt(10)*z*(3 - 7*z2)/(8*sqrt(pi))
-		// dy += (float)dL_dy(21) * (0);                               // 0
-		dz += (float)dL_dy(21) * (2.0071396306718676*x*(1.0 - 7.0*z2));                                // 9*sqrt(10)*x*(1 - 7*z2)/(8*sqrt(pi))
-		dx += (float)dL_dy(22) * (0.94617469575756008*x*(7.0*z2 - 1.0));                               // 3*sqrt(5)*x*(7*z2 - 1)/(4*sqrt(pi))
-		dy += (float)dL_dy(22) * (0.94617469575756008*y*(1.0 - 7.0*z2));                               // 3*sqrt(5)*y*(1 - 7*z2)/(4*sqrt(pi))
-		dz += (float)dL_dy(22) * (6.6232228703029197*z*(x2 - y2));                             // 21*sqrt(5)*z*(x2 - y2)/(4*sqrt(pi))
-		dx += (float)dL_dy(23) * (5.3103923093397913*z*(-x2 + y2));                            // 9*sqrt(70)*z*(-x2 + y2)/(8*sqrt(pi))
-		dy += (float)dL_dy(23) * (10.620784618679583*xy*z);                            // 9*sqrt(70)*xy*z/(4*sqrt(pi))
-		dz += (float)dL_dy(23) * (1.7701307697799304*x*(-x2 + 3.0*y2));                                // 3*sqrt(70)*x*(-x2 + 3*y2)/(8*sqrt(pi))
-		dx += (float)dL_dy(24) * (2.5033429417967046*x*(x2 - 3.0*y2));                         // 3*sqrt(35)*x*(x2 - 3*y2)/(4*sqrt(pi))
-		dy += (float)dL_dy(24) * (2.5033429417967046*y*(-3.0*x2 + y2));                                // 3*sqrt(35)*y*(-3*x2 + y2)/(4*sqrt(pi))
-		// dz += (float)dL_dy(24) * (0);                               // 0
+		dx += (INPUT_T)dL_dy(16) * (INPUT_T(2.5033429417967046)*y*(INPUT_T(3.0)*x2 - y2));                         // 3*sqrt(35)*y*(3*x2 - y2)/(4*sqrt(pi))
+		dy += (INPUT_T)dL_dy(16) * (INPUT_T(2.5033429417967046)*x*(x2 - INPUT_T(3.0)*y2));                         // 3*sqrt(35)*x*(x2 - 3*y2)/(4*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(16) * (0);                               // 0
+		dx += (INPUT_T)dL_dy(17) * (INPUT_T(-10.620784618679583)*xy*z);                           // -9*sqrt(70)*xy*z/(4*sqrt(pi))
+		dy += (INPUT_T)dL_dy(17) * (INPUT_T(5.3103923093397913)*z*(-x2 + y2));                            // 9*sqrt(70)*z*(-x2 + y2)/(8*sqrt(pi))
+		dz += (INPUT_T)dL_dy(17) * (INPUT_T(1.7701307697799304)*y*(INPUT_T(-3.0)*x2 + y2));                                // 3*sqrt(70)*y*(-3*x2 + y2)/(8*sqrt(pi))
+		dx += (INPUT_T)dL_dy(18) * (INPUT_T(0.94617469575756008)*y*(INPUT_T(7.0)*z2 - INPUT_T(1.0)));                               // 3*sqrt(5)*y*(7*z2 - 1)/(4*sqrt(pi))
+		dy += (INPUT_T)dL_dy(18) * (INPUT_T(0.94617469575756008)*x*(INPUT_T(7.0)*z2 - INPUT_T(1.0)));                               // 3*sqrt(5)*x*(7*z2 - 1)/(4*sqrt(pi))
+		dz += (INPUT_T)dL_dy(18) * (INPUT_T(13.246445740605839)*xy*z);                            // 21*sqrt(5)*xy*z/(2*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(19) * (0);                               // 0
+		dy += (INPUT_T)dL_dy(19) * (INPUT_T(0.66904654355728921)*z*(INPUT_T(3.0) - INPUT_T(7.0)*z2));                               // 3*sqrt(10)*z*(3 - 7*z2)/(8*sqrt(pi))
+		dz += (INPUT_T)dL_dy(19) * (INPUT_T(2.0071396306718676)*y*(INPUT_T(1.0) - INPUT_T(7.0)*z2));                                // 9*sqrt(10)*y*(1 - 7*z2)/(8*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(20) * (0);                               // 0
+		// dy += (INPUT_T)dL_dy(20) * (0);                               // 0
+		dz += (INPUT_T)dL_dy(20) * (INPUT_T(14.809976568128603)*z*z*z - INPUT_T(6.3471328149122579)*z);                                // (105*z**3 - 45*z)/(4*sqrt(pi))
+		dx += (INPUT_T)dL_dy(21) * (INPUT_T(0.66904654355728921)*z*(INPUT_T(3.0) - INPUT_T(7.0)*z2));                               // 3*sqrt(10)*z*(3 - 7*z2)/(8*sqrt(pi))
+		// dy += (INPUT_T)dL_dy(21) * (0);                               // 0
+		dz += (INPUT_T)dL_dy(21) * (INPUT_T(2.0071396306718676)*x*(INPUT_T(1.0) - INPUT_T(7.0)*z2));                                // 9*sqrt(10)*x*(1 - 7*z2)/(8*sqrt(pi))
+		dx += (INPUT_T)dL_dy(22) * (INPUT_T(0.94617469575756008)*x*(INPUT_T(7.0)*z2 - INPUT_T(1.0)));                               // 3*sqrt(5)*x*(7*z2 - 1)/(4*sqrt(pi))
+		dy += (INPUT_T)dL_dy(22) * (INPUT_T(0.94617469575756008)*y*(INPUT_T(1.0) - INPUT_T(7.0)*z2));                               // 3*sqrt(5)*y*(1 - 7*z2)/(4*sqrt(pi))
+		dz += (INPUT_T)dL_dy(22) * (INPUT_T(6.6232228703029197)*z*(x2 - y2));                             // 21*sqrt(5)*z*(x2 - y2)/(4*sqrt(pi))
+		dx += (INPUT_T)dL_dy(23) * (INPUT_T(5.3103923093397913)*z*(-x2 + y2));                            // 9*sqrt(70)*z*(-x2 + y2)/(8*sqrt(pi))
+		dy += (INPUT_T)dL_dy(23) * (INPUT_T(10.620784618679583)*xy*z);                            // 9*sqrt(70)*xy*z/(4*sqrt(pi))
+		dz += (INPUT_T)dL_dy(23) * (INPUT_T(1.7701307697799304)*x*(-x2 + INPUT_T(3.0)*y2));                                // 3*sqrt(70)*x*(-x2 + 3*y2)/(8*sqrt(pi))
+		dx += (INPUT_T)dL_dy(24) * (INPUT_T(2.5033429417967046)*x*(x2 - INPUT_T(3.0)*y2));                         // 3*sqrt(35)*x*(x2 - 3*y2)/(4*sqrt(pi))
+		dy += (INPUT_T)dL_dy(24) * (INPUT_T(2.5033429417967046)*y*(INPUT_T(-3.0)*x2 + y2));                                // 3*sqrt(35)*y*(-3*x2 + y2)/(4*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(24) * (0);                               // 0
 		if (degree <= 5) { return; }
-		dx += (float)dL_dy(25) * (13.127641136803401*xy*(-x2 + y2));                           // 15*sqrt(154)*xy*(-x2 + y2)/(8*sqrt(pi))
-		dy += (float)dL_dy(25) * (19.6914617052051*x2*y2 - 3.2819102842008503*x4 - 3.2819102842008503*y4);                             // 15*sqrt(154)*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
-		// dz += (float)dL_dy(25) * (0);                               // 0
-		dx += (float)dL_dy(26) * (8.3026492595241645*yz*(3.0*x2 - y2));                                // 3*sqrt(385)*yz*(3*x2 - y2)/(4*sqrt(pi))
-		dy += (float)dL_dy(26) * (8.3026492595241645*xz*(x2 - 3.0*y2));                                // 3*sqrt(385)*xz*(x2 - 3*y2)/(4*sqrt(pi))
-		dz += (float)dL_dy(26) * (8.3026492595241645*xy*(x2 - y2));                            // 3*sqrt(385)*xy*(x2 - y2)/(4*sqrt(pi))
-		dx += (float)dL_dy(27) * (2.9354297966115022*xy*(1.0 - 9.0*z2));                               // 3*sqrt(770)*xy*(1 - 9*z2)/(16*sqrt(pi))
-		dy += (float)dL_dy(27) * (-1.4677148983057511*(x2 - y2)*(9.0*z2 - 1.0));                               // -3*sqrt(770)*(x2 - y2)*(9*z2 - 1)/(32*sqrt(pi))
-		dz += (float)dL_dy(27) * (8.8062893898345074*yz*(-3.0*x2 + y2));                               // 9*sqrt(770)*yz*(-3*x2 + y2)/(16*sqrt(pi))
-		dx += (float)dL_dy(28) * (4.7935367849733241*yz*(3.0*z2 - 1.0));                               // sqrt(1155)*yz*(3*z2 - 1)/(4*sqrt(pi))
-		dy += (float)dL_dy(28) * (4.7935367849733241*xz*(3.0*z2 - 1.0));                               // sqrt(1155)*xz*(3*z2 - 1)/(4*sqrt(pi))
-		dz += (float)dL_dy(28) * (4.7935367849733241*xy*(9.0*z2 - 1.0));                               // sqrt(1155)*xy*(9*z2 - 1)/(4*sqrt(pi))
-		// dx += (float)dL_dy(29) * (0);                               // 0
-		dy += (float)dL_dy(29) * (6.3412531167397574*z2 - 9.5118796751096362*z4 - 0.45294665119569694);                                // sqrt(165)*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
-		dz += (float)dL_dy(29) * (12.682506233479513*yz*(1.0 - 3.0*z2));                               // 7*sqrt(165)*yz*(1 - 3*z2)/(4*sqrt(pi))
-		// dx += (float)dL_dy(30) * (0);                               // 0
-		// dy += (float)dL_dy(30) * (0);                               // 0
-		dz += (float)dL_dy(30) * (-24.559567715218954*z2 + 36.839351572828434*z4 + 1.754254836801354);                         // 15*sqrt(11)*(-14*z2 + 21*z4 + 1)/(16*sqrt(pi))
-		dx += (float)dL_dy(31) * (6.3412531167397574*z2 - 9.5118796751096362*z4 - 0.45294665119569694);                                // sqrt(165)*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
-		// dy += (float)dL_dy(31) * (0);                               // 0
-		dz += (float)dL_dy(31) * (12.682506233479513*xz*(1.0 - 3.0*z2));                               // 7*sqrt(165)*xz*(1 - 3*z2)/(4*sqrt(pi))
-		dx += (float)dL_dy(32) * (4.7935367849733241*xz*(3.0*z2 - 1.0));                               // sqrt(1155)*xz*(3*z2 - 1)/(4*sqrt(pi))
-		dy += (float)dL_dy(32) * (4.7935367849733241*yz*(1.0 - 3.0*z2));                               // sqrt(1155)*yz*(1 - 3*z2)/(4*sqrt(pi))
-		dz += (float)dL_dy(32) * (2.3967683924866621*(x2 - y2)*(9.0*z2 - 1.0));                                // sqrt(1155)*(x2 - y2)*(9*z2 - 1)/(8*sqrt(pi))
-		dx += (float)dL_dy(33) * (-13.209434084751759*x2*z2 + 1.4677148983057511*x2 + 13.209434084751759*y2*z2 - 1.4677148983057511*y2);                               // 3*sqrt(770)*(-9*x2*z2 + x2 + 9*y2*z2 - y2)/(32*sqrt(pi))
-		dy += (float)dL_dy(33) * (2.9354297966115022*xy*(9.0*z2 - 1.0));                               // 3*sqrt(770)*xy*(9*z2 - 1)/(16*sqrt(pi))
-		dz += (float)dL_dy(33) * (8.8062893898345074*xz*(-x2 + 3.0*y2));                               // 9*sqrt(770)*xz*(-x2 + 3*y2)/(16*sqrt(pi))
-		dx += (float)dL_dy(34) * (8.3026492595241645*xz*(x2 - 3.0*y2));                                // 3*sqrt(385)*xz*(x2 - 3*y2)/(4*sqrt(pi))
-		dy += (float)dL_dy(34) * (8.3026492595241645*yz*(-3.0*x2 + y2));                               // 3*sqrt(385)*yz*(-3*x2 + y2)/(4*sqrt(pi))
-		dz += (float)dL_dy(34) * (-12.453973889286246*x2*y2 + 2.0756623148810411*x4 + 2.0756623148810411*y4);                          // 3*sqrt(385)*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
-		dx += (float)dL_dy(35) * (19.6914617052051*x2*y2 - 3.2819102842008503*x4 - 3.2819102842008503*y4);                             // 15*sqrt(154)*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
-		dy += (float)dL_dy(35) * (13.127641136803401*xy*(x2 - y2));                            // 15*sqrt(154)*xy*(x2 - y2)/(8*sqrt(pi))
-		// dz += (float)dL_dy(35) * (0);                               // 0
+		dx += (INPUT_T)dL_dy(25) * (INPUT_T(13.127641136803401)*xy*(-x2 + y2));                           // 15*sqrt(154)*xy*(-x2 + y2)/(8*sqrt(pi))
+		dy += (INPUT_T)dL_dy(25) * (INPUT_T(19.6914617052051)*x2*y2 - INPUT_T(3.2819102842008503)*x4 - INPUT_T(3.2819102842008503)*y4);                             // 15*sqrt(154)*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(25) * (0);                               // 0
+		dx += (INPUT_T)dL_dy(26) * (INPUT_T(8.3026492595241645)*yz*(INPUT_T(3.0)*x2 - y2));                                // 3*sqrt(385)*yz*(3*x2 - y2)/(4*sqrt(pi))
+		dy += (INPUT_T)dL_dy(26) * (INPUT_T(8.3026492595241645)*xz*(x2 - INPUT_T(3.0)*y2));                                // 3*sqrt(385)*xz*(x2 - 3*y2)/(4*sqrt(pi))
+		dz += (INPUT_T)dL_dy(26) * (INPUT_T(8.3026492595241645)*xy*(x2 - y2));                            // 3*sqrt(385)*xy*(x2 - y2)/(4*sqrt(pi))
+		dx += (INPUT_T)dL_dy(27) * (INPUT_T(2.9354297966115022)*xy*(INPUT_T(1.0) - INPUT_T(9.0)*z2));                               // 3*sqrt(770)*xy*(1 - 9*z2)/(16*sqrt(pi))
+		dy += (INPUT_T)dL_dy(27) * (INPUT_T(-1.4677148983057511)*(x2 - y2)*(INPUT_T(9.0)*z2 - INPUT_T(1.0)));                               // -3*sqrt(770)*(x2 - y2)*(9*z2 - 1)/(32*sqrt(pi))
+		dz += (INPUT_T)dL_dy(27) * (INPUT_T(8.8062893898345074)*yz*(INPUT_T(-3.0)*x2 + y2));                               // 9*sqrt(770)*yz*(-3*x2 + y2)/(16*sqrt(pi))
+		dx += (INPUT_T)dL_dy(28) * (INPUT_T(4.7935367849733241)*yz*(INPUT_T(3.0)*z2 - INPUT_T(1.0)));                               // sqrt(1155)*yz*(3*z2 - 1)/(4*sqrt(pi))
+		dy += (INPUT_T)dL_dy(28) * (INPUT_T(4.7935367849733241)*xz*(INPUT_T(3.0)*z2 - INPUT_T(1.0)));                               // sqrt(1155)*xz*(3*z2 - 1)/(4*sqrt(pi))
+		dz += (INPUT_T)dL_dy(28) * (INPUT_T(4.7935367849733241)*xy*(INPUT_T(9.0)*z2 - INPUT_T(1.0)));                               // sqrt(1155)*xy*(9*z2 - 1)/(4*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(29) * (0);                               // 0
+		dy += (INPUT_T)dL_dy(29) * (INPUT_T(6.3412531167397574)*z2 - INPUT_T(9.5118796751096362)*z4 - INPUT_T(0.45294665119569694));                                // sqrt(165)*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
+		dz += (INPUT_T)dL_dy(29) * (INPUT_T(12.682506233479513)*yz*(INPUT_T(1.0) - INPUT_T(3.0)*z2));                               // 7*sqrt(165)*yz*(1 - 3*z2)/(4*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(30) * (0);                               // 0
+		// dy += (INPUT_T)dL_dy(30) * (0);                               // 0
+		dz += (INPUT_T)dL_dy(30) * (INPUT_T(-24.559567715218954)*z2 + INPUT_T(36.839351572828434)*z4 + INPUT_T(1.754254836801354));                         // 15*sqrt(11)*(-14*z2 + 21*z4 + 1)/(16*sqrt(pi))
+		dx += (INPUT_T)dL_dy(31) * (INPUT_T(6.3412531167397574)*z2 - INPUT_T(9.5118796751096362)*z4 - INPUT_T(0.45294665119569694));                                // sqrt(165)*(14*z2 - 21*z4 - 1)/(16*sqrt(pi))
+		// dy += (INPUT_T)dL_dy(31) * (0);                               // 0
+		dz += (INPUT_T)dL_dy(31) * (INPUT_T(12.682506233479513)*xz*(INPUT_T(1.0) - INPUT_T(3.0)*z2));                               // 7*sqrt(165)*xz*(1 - 3*z2)/(4*sqrt(pi))
+		dx += (INPUT_T)dL_dy(32) * (INPUT_T(4.7935367849733241)*xz*(INPUT_T(3.0)*z2 - INPUT_T(1.0)));                               // sqrt(1155)*xz*(3*z2 - 1)/(4*sqrt(pi))
+		dy += (INPUT_T)dL_dy(32) * (INPUT_T(4.7935367849733241)*yz*(INPUT_T(1.0) - INPUT_T(3.0)*z2));                               // sqrt(1155)*yz*(1 - 3*z2)/(4*sqrt(pi))
+		dz += (INPUT_T)dL_dy(32) * (INPUT_T(2.3967683924866621)*(x2 - y2)*(INPUT_T(9.0)*z2 - INPUT_T(1.0)));                                // sqrt(1155)*(x2 - y2)*(9*z2 - 1)/(8*sqrt(pi))
+		dx += (INPUT_T)dL_dy(33) * (INPUT_T(-13.209434084751759)*x2*z2 + INPUT_T(1.4677148983057511)*x2 + INPUT_T(13.209434084751759)*y2*z2 - INPUT_T(1.4677148983057511)*y2);                               // 3*sqrt(770)*(-9*x2*z2 + x2 + 9*y2*z2 - y2)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(33) * (INPUT_T(2.9354297966115022)*xy*(INPUT_T(9.0)*z2 - INPUT_T(1.0)));                               // 3*sqrt(770)*xy*(9*z2 - 1)/(16*sqrt(pi))
+		dz += (INPUT_T)dL_dy(33) * (INPUT_T(8.8062893898345074)*xz*(-x2 + INPUT_T(3.0)*y2));                               // 9*sqrt(770)*xz*(-x2 + 3*y2)/(16*sqrt(pi))
+		dx += (INPUT_T)dL_dy(34) * (INPUT_T(8.3026492595241645)*xz*(x2 - INPUT_T(3.0)*y2));                                // 3*sqrt(385)*xz*(x2 - 3*y2)/(4*sqrt(pi))
+		dy += (INPUT_T)dL_dy(34) * (INPUT_T(8.3026492595241645)*yz*(INPUT_T(-3.0)*x2 + y2));                               // 3*sqrt(385)*yz*(-3*x2 + y2)/(4*sqrt(pi))
+		dz += (INPUT_T)dL_dy(34) * (INPUT_T(-12.453973889286246)*x2*y2 + INPUT_T(2.0756623148810411)*x4 + INPUT_T(2.0756623148810411)*y4);                          // 3*sqrt(385)*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
+		dx += (INPUT_T)dL_dy(35) * (INPUT_T(19.6914617052051)*x2*y2 - INPUT_T(3.2819102842008503)*x4 - INPUT_T(3.2819102842008503)*y4);                             // 15*sqrt(154)*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(35) * (INPUT_T(13.127641136803401)*xy*(x2 - y2));                            // 15*sqrt(154)*xy*(x2 - y2)/(8*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(35) * (0);                               // 0
 		if (degree <= 6) { return; }
-		dx += (float)dL_dy(36) * (4.0991046311514854*y*(-10.0*x2*y2 + 5.0*x4 + y4));                           // 3*sqrt(6006)*y*(-10*x2*y2 + 5*x4 + y4)/(32*sqrt(pi))
-		dy += (float)dL_dy(36) * (4.0991046311514854*x*(-10.0*x2*y2 + x4 + 5.0*y4));                           // 3*sqrt(6006)*x*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
-		// dz += (float)dL_dy(36) * (0);                               // 0
-		dx += (float)dL_dy(37) * (47.332383244635047*xy*z*(-x2 + y2));                         // 15*sqrt(2002)*xy*z*(-x2 + y2)/(8*sqrt(pi))
-		dy += (float)dL_dy(37) * (11.833095811158762*z*(6.0*x2*y2 - x4 - y4));                         // 15*sqrt(2002)*z*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
-		dz += (float)dL_dy(37) * (2.3666191622317521*y*(10.0*x2*y2 - 5.0*x4 - y4));                            // 3*sqrt(2002)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		dx += (float)dL_dy(38) * (2.0182596029148963*y*(3.0*x2 - y2)*(11.0*z2 - 1.0));                         // 3*sqrt(91)*y*(3*x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
-		dy += (float)dL_dy(38) * (2.0182596029148963*x*(x2 - 3.0*y2)*(11.0*z2 - 1.0));                         // 3*sqrt(91)*x*(x2 - 3*y2)*(11*z2 - 1)/(8*sqrt(pi))
-		dz += (float)dL_dy(38) * (44.401711264127719*xy*z*(x2 - y2));                          // 33*sqrt(91)*xy*z*(x2 - y2)/(4*sqrt(pi))
-		dx += (float)dL_dy(39) * (5.5272315570895412*xy*z*(3.0 - 11.0*z2));                            // 3*sqrt(2730)*xy*z*(3 - 11*z2)/(16*sqrt(pi))
-		dy += (float)dL_dy(39) * (-2.7636157785447706*z*(x2 - y2)*(11.0*z2 - 3.0));                            // -3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
-		dz += (float)dL_dy(39) * (-2.7636157785447706*y*(3.0*x2 - y2)*(11.0*z2 - 1.0));                                // -3*sqrt(2730)*y*(3*x2 - y2)*(11*z2 - 1)/(32*sqrt(pi))
-		dx += (float)dL_dy(40) * (0.92120525951492349*y*(-18.0*z2 + 33.0*z4 + 1.0));                           // sqrt(2730)*y*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
-		dy += (float)dL_dy(40) * (0.92120525951492349*x*(-18.0*z2 + 33.0*z4 + 1.0));                           // sqrt(2730)*x*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
-		dz += (float)dL_dy(40) * (11.054463114179082*xy*z*(11.0*z2 - 3.0));                            // 3*sqrt(2730)*xy*z*(11*z2 - 3)/(8*sqrt(pi))
-		// dx += (float)dL_dy(41) * (0);                               // 0
-		dy += (float)dL_dy(41) * (0.58262136251873131*z*(30.0*z2 - 33.0*z4 - 5.0));                            // sqrt(273)*z*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
-		dz += (float)dL_dy(41) * (2.9131068125936568*y*(18.0*z2 - 33.0*z4 - 1.0));                             // 5*sqrt(273)*y*(18*z2 - 33*z4 - 1)/(16*sqrt(pi))
-		// dx += (float)dL_dy(42) * (0);                               // 0
-		// dy += (float)dL_dy(42) * (0);                               // 0
-		dz += (float)dL_dy(42) * (2.6699064952403937*z*(-30.0*z2 + 33.0*z4 + 5.0));                            // 21*sqrt(13)*z*(-30*z2 + 33*z4 + 5)/(16*sqrt(pi))
-		dx += (float)dL_dy(43) * (0.58262136251873131*z*(30.0*z2 - 33.0*z4 - 5.0));                            // sqrt(273)*z*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
-		// dy += (float)dL_dy(43) * (0);                               // 0
-		dz += (float)dL_dy(43) * (2.9131068125936568*x*(18.0*z2 - 33.0*z4 - 1.0));                             // 5*sqrt(273)*x*(18*z2 - 33*z4 - 1)/(16*sqrt(pi))
-		dx += (float)dL_dy(44) * (0.92120525951492349*x*(-18.0*z2 + 33.0*z4 + 1.0));                           // sqrt(2730)*x*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
-		dy += (float)dL_dy(44) * (0.92120525951492349*y*(18.0*z2 - 33.0*z4 - 1.0));                            // sqrt(2730)*y*(18*z2 - 33*z4 - 1)/(32*sqrt(pi))
-		dz += (float)dL_dy(44) * (5.5272315570895412*z*(x2 - y2)*(11.0*z2 - 3.0));                             // 3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(16*sqrt(pi))
-		dx += (float)dL_dy(45) * (-2.7636157785447706*z*(x2 - y2)*(11.0*z2 - 3.0));                            // -3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
-		dy += (float)dL_dy(45) * (5.5272315570895412*xy*z*(11.0*z2 - 3.0));                            // 3*sqrt(2730)*xy*z*(11*z2 - 3)/(16*sqrt(pi))
-		dz += (float)dL_dy(45) * (-2.7636157785447706*x*(x2 - 3.0*y2)*(11.0*z2 - 1.0));                                // -3*sqrt(2730)*x*(x2 - 3*y2)*(11*z2 - 1)/(32*sqrt(pi))
-		dx += (float)dL_dy(46) * (2.0182596029148963*x*(x2 - 3.0*y2)*(11.0*z2 - 1.0));                         // 3*sqrt(91)*x*(x2 - 3*y2)*(11*z2 - 1)/(8*sqrt(pi))
-		dy += (float)dL_dy(46) * (-2.0182596029148963*y*(3.0*x2 - y2)*(11.0*z2 - 1.0));                                // -3*sqrt(91)*y*(3*x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
-		dz += (float)dL_dy(46) * (11.10042781603193*z*(-6.0*x2*y2 + x4 + y4));                         // 33*sqrt(91)*z*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
-		dx += (float)dL_dy(47) * (11.833095811158762*z*(6.0*x2*y2 - x4 - y4));                         // 15*sqrt(2002)*z*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
-		dy += (float)dL_dy(47) * (47.332383244635047*xy*z*(x2 - y2));                          // 15*sqrt(2002)*xy*z*(x2 - y2)/(8*sqrt(pi))
-		dz += (float)dL_dy(47) * (2.3666191622317521*x*(10.0*x2*y2 - x4 - 5.0*y4));                            // 3*sqrt(2002)*x*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
-		dx += (float)dL_dy(48) * (4.0991046311514854*x*(-10.0*x2*y2 + x4 + 5.0*y4));                           // 3*sqrt(6006)*x*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
-		dy += (float)dL_dy(48) * (4.0991046311514854*y*(10.0*x2*y2 - 5.0*x4 - y4));                            // 3*sqrt(6006)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		// dz += (float)dL_dy(48) * (0);                               // 0
+		dx += (INPUT_T)dL_dy(36) * (INPUT_T(4.0991046311514854)*y*(INPUT_T(-10.0)*x2*y2 + INPUT_T(5.0)*x4 + y4));                           // 3*sqrt(6006)*y*(-10*x2*y2 + 5*x4 + y4)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(36) * (INPUT_T(4.0991046311514854)*x*(INPUT_T(-10.0)*x2*y2 + x4 + INPUT_T(5.0)*y4));                           // 3*sqrt(6006)*x*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(36) * (0);                               // 0
+		dx += (INPUT_T)dL_dy(37) * (INPUT_T(47.332383244635047)*xy*z*(-x2 + y2));                         // 15*sqrt(2002)*xy*z*(-x2 + y2)/(8*sqrt(pi))
+		dy += (INPUT_T)dL_dy(37) * (INPUT_T(11.833095811158762)*z*(INPUT_T(6.0)*x2*y2 - x4 - y4));                         // 15*sqrt(2002)*z*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
+		dz += (INPUT_T)dL_dy(37) * (INPUT_T(2.3666191622317521)*y*(INPUT_T(10.0)*x2*y2 - INPUT_T(5.0)*x4 - y4));                            // 3*sqrt(2002)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		dx += (INPUT_T)dL_dy(38) * (INPUT_T(2.0182596029148963)*y*(INPUT_T(3.0)*x2 - y2)*(INPUT_T(11.0)*z2 - INPUT_T(1.0)));                         // 3*sqrt(91)*y*(3*x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
+		dy += (INPUT_T)dL_dy(38) * (INPUT_T(2.0182596029148963)*x*(x2 - INPUT_T(3.0)*y2)*(INPUT_T(11.0)*z2 - INPUT_T(1.0)));                         // 3*sqrt(91)*x*(x2 - 3*y2)*(11*z2 - 1)/(8*sqrt(pi))
+		dz += (INPUT_T)dL_dy(38) * (INPUT_T(44.401711264127719)*xy*z*(x2 - y2));                          // 33*sqrt(91)*xy*z*(x2 - y2)/(4*sqrt(pi))
+		dx += (INPUT_T)dL_dy(39) * (INPUT_T(5.5272315570895412)*xy*z*(INPUT_T(3.0) - INPUT_T(11.0)*z2));                            // 3*sqrt(2730)*xy*z*(3 - 11*z2)/(16*sqrt(pi))
+		dy += (INPUT_T)dL_dy(39) * (INPUT_T(-2.7636157785447706)*z*(x2 - y2)*(INPUT_T(11.0)*z2 - INPUT_T(3.0)));                            // -3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
+		dz += (INPUT_T)dL_dy(39) * (INPUT_T(-2.7636157785447706)*y*(INPUT_T(3.0)*x2 - y2)*(INPUT_T(11.0)*z2 - INPUT_T(1.0)));                                // -3*sqrt(2730)*y*(3*x2 - y2)*(11*z2 - 1)/(32*sqrt(pi))
+		dx += (INPUT_T)dL_dy(40) * (INPUT_T(0.92120525951492349)*y*(INPUT_T(-18.0)*z2 + INPUT_T(33.0)*z4 + INPUT_T(1.0)));                           // sqrt(2730)*y*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(40) * (INPUT_T(0.92120525951492349)*x*(INPUT_T(-18.0)*z2 + INPUT_T(33.0)*z4 + INPUT_T(1.0)));                           // sqrt(2730)*x*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
+		dz += (INPUT_T)dL_dy(40) * (INPUT_T(11.054463114179082)*xy*z*(INPUT_T(11.0)*z2 - INPUT_T(3.0)));                            // 3*sqrt(2730)*xy*z*(11*z2 - 3)/(8*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(41) * (0);                               // 0
+		dy += (INPUT_T)dL_dy(41) * (INPUT_T(0.58262136251873131)*z*(INPUT_T(30.0)*z2 - INPUT_T(33.0)*z4 - INPUT_T(5.0)));                            // sqrt(273)*z*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
+		dz += (INPUT_T)dL_dy(41) * (INPUT_T(2.9131068125936568)*y*(INPUT_T(18.0)*z2 - INPUT_T(33.0)*z4 - INPUT_T(1.0)));                             // 5*sqrt(273)*y*(18*z2 - 33*z4 - 1)/(16*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(42) * (0);                               // 0
+		// dy += (INPUT_T)dL_dy(42) * (0);                               // 0
+		dz += (INPUT_T)dL_dy(42) * (INPUT_T(2.6699064952403937)*z*(INPUT_T(-30.0)*z2 + INPUT_T(33.0)*z4 + INPUT_T(5.0)));                            // 21*sqrt(13)*z*(-30*z2 + 33*z4 + 5)/(16*sqrt(pi))
+		dx += (INPUT_T)dL_dy(43) * (INPUT_T(0.58262136251873131)*z*(INPUT_T(30.0)*z2 - INPUT_T(33.0)*z4 - INPUT_T(5.0)));                            // sqrt(273)*z*(30*z2 - 33*z4 - 5)/(16*sqrt(pi))
+		// dy += (INPUT_T)dL_dy(43) * (0);                               // 0
+		dz += (INPUT_T)dL_dy(43) * (INPUT_T(2.9131068125936568)*x*(INPUT_T(18.0)*z2 - INPUT_T(33.0)*z4 - INPUT_T(1.0)));                             // 5*sqrt(273)*x*(18*z2 - 33*z4 - 1)/(16*sqrt(pi))
+		dx += (INPUT_T)dL_dy(44) * (INPUT_T(0.92120525951492349)*x*(INPUT_T(-18.0)*z2 + INPUT_T(33.0)*z4 + INPUT_T(1.0)));                           // sqrt(2730)*x*(-18*z2 + 33*z4 + 1)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(44) * (INPUT_T(0.92120525951492349)*y*(INPUT_T(18.0)*z2 - INPUT_T(33.0)*z4 - INPUT_T(1.0)));                            // sqrt(2730)*y*(18*z2 - 33*z4 - 1)/(32*sqrt(pi))
+		dz += (INPUT_T)dL_dy(44) * (INPUT_T(5.5272315570895412)*z*(x2 - y2)*(INPUT_T(11.0)*z2 - INPUT_T(3.0)));                             // 3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(16*sqrt(pi))
+		dx += (INPUT_T)dL_dy(45) * (INPUT_T(-2.7636157785447706)*z*(x2 - y2)*(INPUT_T(11.0)*z2 - INPUT_T(3.0)));                            // -3*sqrt(2730)*z*(x2 - y2)*(11*z2 - 3)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(45) * (INPUT_T(5.5272315570895412)*xy*z*(INPUT_T(11.0)*z2 - INPUT_T(3.0)));                            // 3*sqrt(2730)*xy*z*(11*z2 - 3)/(16*sqrt(pi))
+		dz += (INPUT_T)dL_dy(45) * (INPUT_T(-2.7636157785447706)*x*(x2 - INPUT_T(3.0)*y2)*(INPUT_T(11.0)*z2 - INPUT_T(1.0)));                                // -3*sqrt(2730)*x*(x2 - 3*y2)*(11*z2 - 1)/(32*sqrt(pi))
+		dx += (INPUT_T)dL_dy(46) * (INPUT_T(2.0182596029148963)*x*(x2 - INPUT_T(3.0)*y2)*(INPUT_T(11.0)*z2 - INPUT_T(1.0)));                         // 3*sqrt(91)*x*(x2 - 3*y2)*(11*z2 - 1)/(8*sqrt(pi))
+		dy += (INPUT_T)dL_dy(46) * (INPUT_T(-2.0182596029148963)*y*(INPUT_T(3.0)*x2 - y2)*(INPUT_T(11.0)*z2 - INPUT_T(1.0)));                                // -3*sqrt(91)*y*(3*x2 - y2)*(11*z2 - 1)/(8*sqrt(pi))
+		dz += (INPUT_T)dL_dy(46) * (INPUT_T(11.10042781603193)*z*(INPUT_T(-6.0)*x2*y2 + x4 + y4));                         // 33*sqrt(91)*z*(-6*x2*y2 + x4 + y4)/(16*sqrt(pi))
+		dx += (INPUT_T)dL_dy(47) * (INPUT_T(11.833095811158762)*z*(INPUT_T(6.0)*x2*y2 - x4 - y4));                         // 15*sqrt(2002)*z*(6*x2*y2 - x4 - y4)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(47) * (INPUT_T(47.332383244635047)*xy*z*(x2 - y2));                          // 15*sqrt(2002)*xy*z*(x2 - y2)/(8*sqrt(pi))
+		dz += (INPUT_T)dL_dy(47) * (INPUT_T(2.3666191622317521)*x*(INPUT_T(10.0)*x2*y2 - x4 - INPUT_T(5.0)*y4));                            // 3*sqrt(2002)*x*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
+		dx += (INPUT_T)dL_dy(48) * (INPUT_T(4.0991046311514854)*x*(INPUT_T(-10.0)*x2*y2 + x4 + INPUT_T(5.0)*y4));                           // 3*sqrt(6006)*x*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(48) * (INPUT_T(4.0991046311514854)*y*(INPUT_T(10.0)*x2*y2 - INPUT_T(5.0)*x4 - y4));                            // 3*sqrt(6006)*y*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(48) * (0);                               // 0
 		if (degree <= 7) { return; }
-		dx += (float)dL_dy(49) * (9.9002782553443485*xy*(10.0*x2*y2 - 3.0*x4 - 3.0*y4));                               // 21*sqrt(715)*xy*(10*x2*y2 - 3*x4 - 3*y4)/(32*sqrt(pi))
-		dy += (float)dL_dy(49) * (-74.252086915082614*x2*y4 + 74.252086915082614*x4*y2 - 4.9501391276721742*x6 + 4.9501391276721742*y6);                               // 21*sqrt(715)*(-15*x2*y4 + 15*x4*y2 - x6 + y6)/(64*sqrt(pi))
-		// dz += (float)dL_dy(49) * (0);                               // 0
-		dx += (float)dL_dy(50) * (15.875763970811402*yz*(-10.0*x2*y2 + 5.0*x4 + y4));                          // 9*sqrt(10010)*yz*(-10*x2*y2 + 5*x4 + y4)/(32*sqrt(pi))
-		dy += (float)dL_dy(50) * (15.875763970811402*xz*(-10.0*x2*y2 + x4 + 5.0*y4));                          // 9*sqrt(10010)*xz*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
-		dz += (float)dL_dy(50) * (5.2919213236038001*xy*(-10.0*x2*y2 + 3.0*x4 + 3.0*y4));                              // 3*sqrt(10010)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
-		dx += (float)dL_dy(51) * (-10.378311574405206*xy*(x2 - y2)*(13.0*z2 - 1.0));                           // -15*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(16*sqrt(pi))
-		dy += (float)dL_dy(51) * (0.51891557872026028*(13.0*z2 - 1.0)*(10.0*x2*y2 - 5.0*x4 + 4.0*y2*(5.0*x2 - y2) - y4));                              // 3*sqrt(385)*(13*z2 - 1)*(10*x2*y2 - 5*x4 + 4*y2*(5*x2 - y2) - y4)/(64*sqrt(pi))
-		dz += (float)dL_dy(51) * (13.491805046726766*yz*(10.0*x2*y2 - 5.0*x4 - y4));                           // 39*sqrt(385)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		dx += (float)dL_dy(52) * (4.1513246297620823*yz*(3.0*x2 - y2)*(13.0*z2 - 3.0));                                // 3*sqrt(385)*yz*(3*x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
-		dy += (float)dL_dy(52) * (4.1513246297620823*xz*(x2 - 3.0*y2)*(13.0*z2 - 3.0));                                // 3*sqrt(385)*xz*(x2 - 3*y2)*(13*z2 - 3)/(8*sqrt(pi))
-		dz += (float)dL_dy(52) * (12.453973889286248*xy*(x2 - y2)*(13.0*z2 - 1.0));                            // 9*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(8*sqrt(pi))
-		dx += (float)dL_dy(53) * (0.93875360317376422*xy*(66.0*z2 - 143.0*z4 - 3.0));                          // 9*sqrt(35)*xy*(66*z2 - 143*z4 - 3)/(32*sqrt(pi))
-		dy += (float)dL_dy(53) * (-0.46937680158688211*(x2 - y2)*(13.0*z2*(11.0*z2 - 3.0) - 27.0*z2 + 3.0));                           // -9*sqrt(35)*(x2 - y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
-		dz += (float)dL_dy(53) * (-6.8841930899409371*yz*(3.0*x2 - y2)*(13.0*z2 - 3.0));                               // -33*sqrt(35)*yz*(3*x2 - y2)*(13*z2 - 3)/(16*sqrt(pi))
-		dx += (float)dL_dy(54) * (0.44253269244498261*yz*(-110.0*z2 + 143.0*z4 + 15.0));                               // 3*sqrt(70)*yz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
-		dy += (float)dL_dy(54) * (0.44253269244498261*xz*(-110.0*z2 + 143.0*z4 + 15.0));                               // 3*sqrt(70)*xz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
-		dz += (float)dL_dy(54) * (2.2126634622249131*xy*(-66.0*z2 + 143.0*z4 + 3.0));                          // 15*sqrt(70)*xy*(-66*z2 + 143*z4 + 3)/(32*sqrt(pi))
-		// dx += (float)dL_dy(55) * (0);                               // 0
-		dy += (float)dL_dy(55) * (-12.194767023639836*z2 + 44.714145753346067*z4 - 38.752259652899923*z6 + 0.45165803791258652);                               // sqrt(105)*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
-		dz += (float)dL_dy(55) * (1.6259689364853116*yz*(110.0*z2 - 143.0*z4 - 15.0));                         // 9*sqrt(105)*yz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
-		// dx += (float)dL_dy(56) * (0);                               // 0
-		// dy += (float)dL_dy(56) * (0);                               // 0
-		dz += (float)dL_dy(56) * (64.528641681844675*z2 - 236.60501950009714*z4 + 205.05768356675085*z6 - 2.3899496919201733);                         // 7*sqrt(15)*(135*z2 - 495*z4 + 429*z6 - 5)/(32*sqrt(pi))
-		dx += (float)dL_dy(57) * (-12.194767023639836*z2 + 44.714145753346067*z4 - 38.752259652899923*z6 + 0.45165803791258652);                               // sqrt(105)*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
-		// dy += (float)dL_dy(57) * (0);                               // 0
-		dz += (float)dL_dy(57) * (1.6259689364853116*xz*(110.0*z2 - 143.0*z4 - 15.0));                         // 9*sqrt(105)*xz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
-		dx += (float)dL_dy(58) * (0.44253269244498261*xz*(-110.0*z2 + 143.0*z4 + 15.0));                               // 3*sqrt(70)*xz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
-		dy += (float)dL_dy(58) * (0.44253269244498261*yz*(110.0*z2 - 143.0*z4 - 15.0));                                // 3*sqrt(70)*yz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
-		dz += (float)dL_dy(58) * (0.07375544874083044*(x2 - y2)*(143.0*z2*(3.0*z2 - 1.0) + 132.0*z2*(13.0*z2 - 5.0) - 187.0*z2 + 45.0));                               // sqrt(70)*(x2 - y2)*(143*z2*(3*z2 - 1) + 132*z2*(13*z2 - 5) - 187*z2 + 45)/(64*sqrt(pi))
-		dx += (float)dL_dy(59) * (30.97886890473422*x2*z2 - 67.120882626924143*x2*z4 - 1.4081304047606462*x2 - 30.97886890473422*y2*z2 + 67.120882626924143*y2*z4 + 1.4081304047606462*y2);                            // 9*sqrt(35)*(66*x2*z2 - 143*x2*z4 - 3*x2 - 66*y2*z2 + 143*y2*z4 + 3*y2)/(64*sqrt(pi))
-		dy += (float)dL_dy(59) * (0.93875360317376422*xy*(-66.0*z2 + 143.0*z4 + 3.0));                         // 9*sqrt(35)*xy*(-66*z2 + 143*z4 + 3)/(32*sqrt(pi))
-		dz += (float)dL_dy(59) * (-6.8841930899409371*xz*(x2 - 3.0*y2)*(13.0*z2 - 3.0));                               // -33*sqrt(35)*xz*(x2 - 3*y2)*(13*z2 - 3)/(16*sqrt(pi))
-		dx += (float)dL_dy(60) * (4.1513246297620823*xz*(x2 - 3.0*y2)*(13.0*z2 - 3.0));                                // 3*sqrt(385)*xz*(x2 - 3*y2)*(13*z2 - 3)/(8*sqrt(pi))
-		dy += (float)dL_dy(60) * (-4.1513246297620823*yz*(3.0*x2 - y2)*(13.0*z2 - 3.0));                               // -3*sqrt(385)*yz*(3*x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
-		dz += (float)dL_dy(60) * (3.1134934723215619*(13.0*z2 - 1.0)*(-6.0*x2*y2 + x4 + y4));                          // 9*sqrt(385)*(13*z2 - 1)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
-		dx += (float)dL_dy(61) * (-0.51891557872026028*(13.0*z2 - 1.0)*(-10.0*x2*y2 + 4.0*x2*(x2 - 5.0*y2) + x4 + 5.0*y4));                            // -3*sqrt(385)*(13*z2 - 1)*(-10*x2*y2 + 4*x2*(x2 - 5*y2) + x4 + 5*y4)/(64*sqrt(pi))
-		dy += (float)dL_dy(61) * (10.378311574405206*xy*(x2 - y2)*(13.0*z2 - 1.0));                            // 15*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(16*sqrt(pi))
-		dz += (float)dL_dy(61) * (13.491805046726766*xz*(10.0*x2*y2 - x4 - 5.0*y4));                           // 39*sqrt(385)*xz*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
-		dx += (float)dL_dy(62) * (15.875763970811402*xz*(-10.0*x2*y2 + x4 + 5.0*y4));                          // 9*sqrt(10010)*xz*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
-		dy += (float)dL_dy(62) * (15.875763970811402*yz*(10.0*x2*y2 - 5.0*x4 - y4));                           // 9*sqrt(10010)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
-		dz += (float)dL_dy(62) * (39.6894099270285*x2*y4 - 39.6894099270285*x4*y2 + 2.6459606618019*x6 - 2.6459606618019*y6);                          // 3*sqrt(10010)*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
-		dx += (float)dL_dy(63) * (-74.252086915082614*x2*y4 + 74.252086915082614*x4*y2 - 4.9501391276721742*x6 + 4.9501391276721742*y6);                               // 21*sqrt(715)*(-15*x2*y4 + 15*x4*y2 - x6 + y6)/(64*sqrt(pi))
-		dy += (float)dL_dy(63) * (9.9002782553443485*xy*(-10.0*x2*y2 + 3.0*x4 + 3.0*y4));                              // 21*sqrt(715)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
-		// dz += (float)dL_dy(63) * (0);                               // 0
+		dx += (INPUT_T)dL_dy(49) * (INPUT_T(9.9002782553443485)*xy*(INPUT_T(10.0)*x2*y2 - INPUT_T(3.0)*x4 - INPUT_T(3.0)*y4));                               // 21*sqrt(715)*xy*(10*x2*y2 - 3*x4 - 3*y4)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(49) * (INPUT_T(-74.252086915082614)*x2*y4 + INPUT_T(74.252086915082614)*x4*y2 - INPUT_T(4.9501391276721742)*x6 + INPUT_T(4.9501391276721742)*y6);                               // 21*sqrt(715)*(-15*x2*y4 + 15*x4*y2 - x6 + y6)/(64*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(49) * (0);                               // 0
+		dx += (INPUT_T)dL_dy(50) * (INPUT_T(15.875763970811402)*yz*(INPUT_T(-10.0)*x2*y2 + INPUT_T(5.0)*x4 + y4));                          // 9*sqrt(10010)*yz*(-10*x2*y2 + 5*x4 + y4)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(50) * (INPUT_T(15.875763970811402)*xz*(INPUT_T(-10.0)*x2*y2 + x4 + INPUT_T(5.0)*y4));                          // 9*sqrt(10010)*xz*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
+		dz += (INPUT_T)dL_dy(50) * (INPUT_T(5.2919213236038001)*xy*(INPUT_T(-10.0)*x2*y2 + INPUT_T(3.0)*x4 + INPUT_T(3.0)*y4));                              // 3*sqrt(10010)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
+		dx += (INPUT_T)dL_dy(51) * (INPUT_T(-10.378311574405206)*xy*(x2 - y2)*(INPUT_T(13.0)*z2 - INPUT_T(1.0)));                           // -15*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(16*sqrt(pi))
+		dy += (INPUT_T)dL_dy(51) * (INPUT_T(0.51891557872026028)*(INPUT_T(13.0)*z2 - INPUT_T(1.0))*(INPUT_T(10.0)*x2*y2 - INPUT_T(5.0)*x4 + INPUT_T(4.0)*y2*(INPUT_T(5.0)*x2 - y2) - y4));                              // 3*sqrt(385)*(13*z2 - 1)*(10*x2*y2 - 5*x4 + 4*y2*(5*x2 - y2) - y4)/(64*sqrt(pi))
+		dz += (INPUT_T)dL_dy(51) * (INPUT_T(13.491805046726766)*yz*(INPUT_T(10.0)*x2*y2 - INPUT_T(5.0)*x4 - y4));                           // 39*sqrt(385)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		dx += (INPUT_T)dL_dy(52) * (INPUT_T(4.1513246297620823)*yz*(INPUT_T(3.0)*x2 - y2)*(INPUT_T(13.0)*z2 - INPUT_T(3.0)));                                // 3*sqrt(385)*yz*(3*x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
+		dy += (INPUT_T)dL_dy(52) * (INPUT_T(4.1513246297620823)*xz*(x2 - INPUT_T(3.0)*y2)*(INPUT_T(13.0)*z2 - INPUT_T(3.0)));                                // 3*sqrt(385)*xz*(x2 - 3*y2)*(13*z2 - 3)/(8*sqrt(pi))
+		dz += (INPUT_T)dL_dy(52) * (INPUT_T(12.453973889286248)*xy*(x2 - y2)*(INPUT_T(13.0)*z2 - INPUT_T(1.0)));                            // 9*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(8*sqrt(pi))
+		dx += (INPUT_T)dL_dy(53) * (INPUT_T(0.93875360317376422)*xy*(INPUT_T(66.0)*z2 - INPUT_T(143.0)*z4 - INPUT_T(3.0)));                          // 9*sqrt(35)*xy*(66*z2 - 143*z4 - 3)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(53) * (INPUT_T(-0.46937680158688211)*(x2 - y2)*(INPUT_T(13.0)*z2*(INPUT_T(11.0)*z2 - INPUT_T(3.0)) - INPUT_T(27.0)*z2 + INPUT_T(3.0)));                           // -9*sqrt(35)*(x2 - y2)*(13*z2*(11*z2 - 3) - 27*z2 + 3)/(64*sqrt(pi))
+		dz += (INPUT_T)dL_dy(53) * (INPUT_T(-6.8841930899409371)*yz*(INPUT_T(3.0)*x2 - y2)*(INPUT_T(13.0)*z2 - INPUT_T(3.0)));                               // -33*sqrt(35)*yz*(3*x2 - y2)*(13*z2 - 3)/(16*sqrt(pi))
+		dx += (INPUT_T)dL_dy(54) * (INPUT_T(0.44253269244498261)*yz*(INPUT_T(-110.0)*z2 + INPUT_T(143.0)*z4 + INPUT_T(15.0)));                               // 3*sqrt(70)*yz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(54) * (INPUT_T(0.44253269244498261)*xz*(INPUT_T(-110.0)*z2 + INPUT_T(143.0)*z4 + INPUT_T(15.0)));                               // 3*sqrt(70)*xz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
+		dz += (INPUT_T)dL_dy(54) * (INPUT_T(2.2126634622249131)*xy*(INPUT_T(-66.0)*z2 + INPUT_T(143.0)*z4 + INPUT_T(3.0)));                          // 15*sqrt(70)*xy*(-66*z2 + 143*z4 + 3)/(32*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(55) * (0);                               // 0
+		dy += (INPUT_T)dL_dy(55) * (INPUT_T(-12.194767023639836)*z2 + INPUT_T(44.714145753346067)*z4 - INPUT_T(38.752259652899923)*z6 + INPUT_T(0.45165803791258652));                               // sqrt(105)*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
+		dz += (INPUT_T)dL_dy(55) * (INPUT_T(1.6259689364853116)*yz*(INPUT_T(110.0)*z2 - INPUT_T(143.0)*z4 - INPUT_T(15.0)));                         // 9*sqrt(105)*yz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
+		// dx += (INPUT_T)dL_dy(56) * (0);                               // 0
+		// dy += (INPUT_T)dL_dy(56) * (0);                               // 0
+		dz += (INPUT_T)dL_dy(56) * (INPUT_T(64.528641681844675)*z2 - INPUT_T(236.60501950009714)*z4 + INPUT_T(205.05768356675085)*z6 - INPUT_T(2.3899496919201733));                         // 7*sqrt(15)*(135*z2 - 495*z4 + 429*z6 - 5)/(32*sqrt(pi))
+		dx += (INPUT_T)dL_dy(57) * (INPUT_T(-12.194767023639836)*z2 + INPUT_T(44.714145753346067)*z4 - INPUT_T(38.752259652899923)*z6 + INPUT_T(0.45165803791258652));                               // sqrt(105)*(-135*z2 + 495*z4 - 429*z6 + 5)/(64*sqrt(pi))
+		// dy += (INPUT_T)dL_dy(57) * (0);                               // 0
+		dz += (INPUT_T)dL_dy(57) * (INPUT_T(1.6259689364853116)*xz*(INPUT_T(110.0)*z2 - INPUT_T(143.0)*z4 - INPUT_T(15.0)));                         // 9*sqrt(105)*xz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
+		dx += (INPUT_T)dL_dy(58) * (INPUT_T(0.44253269244498261)*xz*(INPUT_T(-110.0)*z2 + INPUT_T(143.0)*z4 + INPUT_T(15.0)));                               // 3*sqrt(70)*xz*(-110*z2 + 143*z4 + 15)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(58) * (INPUT_T(0.44253269244498261)*yz*(INPUT_T(110.0)*z2 - INPUT_T(143.0)*z4 - INPUT_T(15.0)));                                // 3*sqrt(70)*yz*(110*z2 - 143*z4 - 15)/(32*sqrt(pi))
+		dz += (INPUT_T)dL_dy(58) * (INPUT_T(0.07375544874083044)*(x2 - y2)*(INPUT_T(143.0)*z2*(INPUT_T(3.0)*z2 - INPUT_T(1.0)) + INPUT_T(132.0)*z2*(INPUT_T(13.0)*z2 - INPUT_T(5.0)) - INPUT_T(187.0)*z2 + INPUT_T(45.0)));                               // sqrt(70)*(x2 - y2)*(143*z2*(3*z2 - 1) + 132*z2*(13*z2 - 5) - 187*z2 + 45)/(64*sqrt(pi))
+		dx += (INPUT_T)dL_dy(59) * (INPUT_T(30.97886890473422)*x2*z2 - INPUT_T(67.120882626924143)*x2*z4 - INPUT_T(1.4081304047606462)*x2 - INPUT_T(30.97886890473422)*y2*z2 + INPUT_T(67.120882626924143)*y2*z4 + INPUT_T(1.4081304047606462)*y2);                            // 9*sqrt(35)*(66*x2*z2 - 143*x2*z4 - 3*x2 - 66*y2*z2 + 143*y2*z4 + 3*y2)/(64*sqrt(pi))
+		dy += (INPUT_T)dL_dy(59) * (INPUT_T(0.93875360317376422)*xy*(INPUT_T(-66.0)*z2 + INPUT_T(143.0)*z4 + INPUT_T(3.0)));                         // 9*sqrt(35)*xy*(-66*z2 + 143*z4 + 3)/(32*sqrt(pi))
+		dz += (INPUT_T)dL_dy(59) * (INPUT_T(-6.8841930899409371)*xz*(x2 - INPUT_T(3.0)*y2)*(INPUT_T(13.0)*z2 - INPUT_T(3.0)));                               // -33*sqrt(35)*xz*(x2 - 3*y2)*(13*z2 - 3)/(16*sqrt(pi))
+		dx += (INPUT_T)dL_dy(60) * (INPUT_T(4.1513246297620823)*xz*(x2 - INPUT_T(3.0)*y2)*(INPUT_T(13.0)*z2 - INPUT_T(3.0)));                                // 3*sqrt(385)*xz*(x2 - 3*y2)*(13*z2 - 3)/(8*sqrt(pi))
+		dy += (INPUT_T)dL_dy(60) * (INPUT_T(-4.1513246297620823)*yz*(INPUT_T(3.0)*x2 - y2)*(INPUT_T(13.0)*z2 - INPUT_T(3.0)));                               // -3*sqrt(385)*yz*(3*x2 - y2)*(13*z2 - 3)/(8*sqrt(pi))
+		dz += (INPUT_T)dL_dy(60) * (INPUT_T(3.1134934723215619)*(INPUT_T(13.0)*z2 - INPUT_T(1.0))*(INPUT_T(-6.0)*x2*y2 + x4 + y4));                          // 9*sqrt(385)*(13*z2 - 1)*(-6*x2*y2 + x4 + y4)/(32*sqrt(pi))
+		dx += (INPUT_T)dL_dy(61) * (INPUT_T(-0.51891557872026028)*(INPUT_T(13.0)*z2 - INPUT_T(1.0))*(INPUT_T(-10.0)*x2*y2 + INPUT_T(4.0)*x2*(x2 - INPUT_T(5.0)*y2) + x4 + INPUT_T(5.0)*y4));                            // -3*sqrt(385)*(13*z2 - 1)*(-10*x2*y2 + 4*x2*(x2 - 5*y2) + x4 + 5*y4)/(64*sqrt(pi))
+		dy += (INPUT_T)dL_dy(61) * (INPUT_T(10.378311574405206)*xy*(x2 - y2)*(INPUT_T(13.0)*z2 - INPUT_T(1.0)));                            // 15*sqrt(385)*xy*(x2 - y2)*(13*z2 - 1)/(16*sqrt(pi))
+		dz += (INPUT_T)dL_dy(61) * (INPUT_T(13.491805046726766)*xz*(INPUT_T(10.0)*x2*y2 - x4 - INPUT_T(5.0)*y4));                           // 39*sqrt(385)*xz*(10*x2*y2 - x4 - 5*y4)/(32*sqrt(pi))
+		dx += (INPUT_T)dL_dy(62) * (INPUT_T(15.875763970811402)*xz*(INPUT_T(-10.0)*x2*y2 + x4 + INPUT_T(5.0)*y4));                          // 9*sqrt(10010)*xz*(-10*x2*y2 + x4 + 5*y4)/(32*sqrt(pi))
+		dy += (INPUT_T)dL_dy(62) * (INPUT_T(15.875763970811402)*yz*(INPUT_T(10.0)*x2*y2 - INPUT_T(5.0)*x4 - y4));                           // 9*sqrt(10010)*yz*(10*x2*y2 - 5*x4 - y4)/(32*sqrt(pi))
+		dz += (INPUT_T)dL_dy(62) * (INPUT_T(39.6894099270285)*x2*y4 - INPUT_T(39.6894099270285)*x4*y2 + INPUT_T(2.6459606618019)*x6 - INPUT_T(2.6459606618019)*y6);                          // 3*sqrt(10010)*(15*x2*y4 - 15*x4*y2 + x6 - y6)/(64*sqrt(pi))
+		dx += (INPUT_T)dL_dy(63) * (INPUT_T(-74.252086915082614)*x2*y4 + INPUT_T(74.252086915082614)*x4*y2 - INPUT_T(4.9501391276721742)*x6 + INPUT_T(4.9501391276721742)*y6);                               // 21*sqrt(715)*(-15*x2*y4 + 15*x4*y2 - x6 + y6)/(64*sqrt(pi))
+		dy += (INPUT_T)dL_dy(63) * (INPUT_T(9.9002782553443485)*xy*(INPUT_T(-10.0)*x2*y2 + INPUT_T(3.0)*x4 + INPUT_T(3.0)*y4));                              // 21*sqrt(715)*xy*(-10*x2*y2 + 3*x4 + 3*y4)/(32*sqrt(pi))
+		// dz += (INPUT_T)dL_dy(63) * (0);                               // 0
 	};
 
 	compute_grad();
@@ -385,13 +385,13 @@ __global__ void kernel_sh_backward(
 	// Multiplication by 2 due to the conversion
 	// from [0,1]^3 to directions in [-1,1]^3.
 	// See implementation in `kernel_sh`.
-	dL_dx(0, i) = dx * 2.0f;
-	dL_dx(1, i) = dy * 2.0f;
-	dL_dx(2, i) = dz * 2.0f;
+	dL_dx(0, i) = dx * INPUT_T(2.0);
+	dL_dx(1, i) = dy * INPUT_T(2.0);
+	dL_dx(2, i) = dz * INPUT_T(2.0);
 }
 
-template <typename T>
-class SphericalHarmonicsEncoding : public Encoding<T> {
+template <typename T, typename INPUT_T = float>
+class SphericalHarmonicsEncoding : public Encoding<T, INPUT_T> {
 public:
 	SphericalHarmonicsEncoding(uint32_t degree, uint32_t n_dims_to_encode)
 	: m_degree{degree}, m_n_dims_to_encode{n_dims_to_encode} {
@@ -412,7 +412,7 @@ public:
 
 	std::unique_ptr<Context> forward_impl(
 		cudaStream_t stream,
-		const GPUMatrixDynamic<float>& input,
+		const GPUMatrixDynamic<INPUT_T>& input,
 		GPUMatrixDynamic<T>* output = nullptr,
 		bool use_inference_params = false,
 		bool prepare_input_gradients = false
@@ -421,7 +421,7 @@ public:
 			return std::make_unique<Context>();
 		}
 
-		linear_kernel(kernel_sh<T>, 0, stream,
+		linear_kernel(kernel_sh<T, INPUT_T>, 0, stream,
 			input.n(),
 			m_degree,
 			m_n_to_pad,
@@ -435,10 +435,10 @@ public:
 	void backward_impl(
 		cudaStream_t stream,
 		const Context& ctx,
-		const GPUMatrixDynamic<float>& input,
+		const GPUMatrixDynamic<INPUT_T>& input,
 		const GPUMatrixDynamic<T>& output,
 		const GPUMatrixDynamic<T>& dL_doutput,
-		GPUMatrixDynamic<float>* dL_dinput = nullptr,
+		GPUMatrixDynamic<INPUT_T>* dL_dinput = nullptr,
 		bool use_inference_params = false,
 		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override {
@@ -446,7 +446,7 @@ public:
 			return;
 		}
 
-		linear_kernel(kernel_sh_backward<T>, 0, stream,
+		linear_kernel(kernel_sh_backward<T, INPUT_T>, 0, stream,
 			input.n(),
 			m_degree,
 			m_n_to_pad,

--- a/include/tiny-cuda-nn/optimizer.h
+++ b/include/tiny-cuda-nn/optimizer.h
@@ -55,8 +55,11 @@ public:
 	virtual T* custom_weights() const = 0;
 
 	virtual bool supports_nesting() const = 0;
-	virtual const std::shared_ptr<Optimizer<T>>& nested() const {
+	virtual const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx = 0) const {
 		throw std::runtime_error{"Optimizer does not support nesting."};
+	}
+	virtual uint32_t num_nesting() const {
+		return this->supports_nesting() ? 1 : 0;
 	}
 
 	virtual json serialize() const { return {}; }

--- a/include/tiny-cuda-nn/optimizer.h
+++ b/include/tiny-cuda-nn/optimizer.h
@@ -53,14 +53,10 @@ public:
 	virtual uint32_t step() const = 0;
 	virtual uint32_t n_weights() const = 0;
 	virtual T* custom_weights() const = 0;
-
-	virtual bool supports_nesting() const = 0;
 	virtual const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx = 0) const {
 		throw std::runtime_error{"Optimizer does not support nesting."};
 	}
-	virtual uint32_t num_nesting() const {
-		return this->supports_nesting() ? 1 : 0;
-	}
+	virtual uint32_t n_nesting() const = 0;
 
 	virtual json serialize() const { return {}; }
 	virtual void deserialize(const json& data) { }

--- a/include/tiny-cuda-nn/optimizers/adam.h
+++ b/include/tiny-cuda-nn/optimizers/adam.h
@@ -208,8 +208,8 @@ public:
 		return nullptr;
 	}
 
-	bool supports_nesting() const override {
-		return false;
+	uint32_t n_nesting() const override {
+		return 0;
 	}
 
 	void update_hyperparams(const json& params) override {

--- a/include/tiny-cuda-nn/optimizers/average.h
+++ b/include/tiny-cuda-nn/optimizers/average.h
@@ -119,8 +119,8 @@ public:
 		return m_weights_samples.data() + current_sample_idx() * m_n_weights;
 	}
 
-	bool supports_nesting() const override {
-		return true;
+	uint32_t n_nesting() const override {
+		return 1;
 	}
 
 	const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {

--- a/include/tiny-cuda-nn/optimizers/average.h
+++ b/include/tiny-cuda-nn/optimizers/average.h
@@ -123,7 +123,8 @@ public:
 		return true;
 	}
 
-	const std::shared_ptr<Optimizer<T>>& nested() const override {
+	const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {
+		CHECK_THROW(idx == 0);
 		return m_nested;
 	}
 

--- a/include/tiny-cuda-nn/optimizers/batched.h
+++ b/include/tiny-cuda-nn/optimizers/batched.h
@@ -109,8 +109,8 @@ public:
 		return m_nested->custom_weights();
 	}
 
-	bool supports_nesting() const override {
-		return true;
+	uint32_t n_nesting() const override {
+		return 1;
 	}
 
 	const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {

--- a/include/tiny-cuda-nn/optimizers/batched.h
+++ b/include/tiny-cuda-nn/optimizers/batched.h
@@ -113,9 +113,11 @@ public:
 		return true;
 	}
 
-	const std::shared_ptr<Optimizer<T>>& nested() const override {
+	const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {
+		CHECK_THROW(idx == 0);
 		return m_nested;
 	}
+
 
 	void update_hyperparams(const json& params) override {
 		if (params.contains("batch_size_multiplier")) {

--- a/include/tiny-cuda-nn/optimizers/composite.h
+++ b/include/tiny-cuda-nn/optimizers/composite.h
@@ -74,7 +74,7 @@ class CompositeOptimizer : public Optimizer<T> {
 						if (m_need_custom_weights) {
 								CUDA_CHECK_THROW(cudaMemcpyAsync(
 								    m_custom_weights.data() + offset,
-								    (m_nested[i]->custom_weights() == nullptr ? weights : m_nested[i]->custom_weights()) + offset,
+								    (m_nested[i]->custom_weights() == nullptr ? weights + offset : m_nested[i]->custom_weights()),
 								    m_nested[i]->n_weights() * sizeof(T), cudaMemcpyDeviceToDevice, stream));
 						}
 				}

--- a/include/tiny-cuda-nn/optimizers/composite.h
+++ b/include/tiny-cuda-nn/optimizers/composite.h
@@ -19,129 +19,132 @@ TCNN_NAMESPACE_BEGIN
 
 std::vector<std::pair<uint32_t, uint32_t>> slice_weights(std::vector<std::pair<uint32_t, uint32_t>> object_layer_size,
                                                          uint32_t offset, uint32_t size) {
-  std::vector<std::pair<uint32_t, uint32_t>> layer_sizes;
-  uint32_t current_offset = 0;
-  uint32_t current_layer = 0;
-  while (current_offset < offset && current_layer < object_layer_size.size()) {
-    current_layer++;
-    current_offset += object_layer_size[current_layer].first * object_layer_size[current_layer].second;
-  }
-  if (current_layer < object_layer_size.size() && current_offset != offset) {
-    throw std::runtime_error{"Invalid slice. Can't slice within a layer"};
-  }
-  for (; current_layer < object_layer_size.size(); current_layer++) {
-    layer_sizes.emplace_back(object_layer_size[current_layer]);
-  }
-  return layer_sizes;
+		std::vector<std::pair<uint32_t, uint32_t>> layer_sizes;
+		uint32_t current_offset = 0;
+		uint32_t current_layer = 0;
+		while (current_offset < offset && current_layer < object_layer_size.size()) {
+				current_layer++;
+				current_offset += object_layer_size[current_layer].first * object_layer_size[current_layer].second;
+		}
+		if (current_layer < object_layer_size.size() && current_offset != offset) {
+				throw std::runtime_error{"Invalid slice. Can't slice within a layer"};
+		}
+		for (; current_layer < object_layer_size.size(); current_layer++) {
+				layer_sizes.emplace_back(object_layer_size[current_layer]);
+		}
+		return layer_sizes;
 }
 
 template <typename T>
 class CompositeOptimizer : public Optimizer<T> {
- public:
-  CompositeOptimizer(const json& params) {
-    if (!params.contains("nested") || !params["nested"].is_array()) {
-      throw std::runtime_error{"Must provide an array of nested encodings to CompositeOptimizer."};
-    }
-    const json::array_t& nested = params["nested"];
-    m_n_weights = 0;
-    for (size_t i = 0; i < nested.size(); ++i) {
-      m_offsets.emplace_back(m_n_weights);
-      m_n_weights += nested[i].value("n_params_to_optimize", 0);
-      m_nested.emplace_back(std::shared_ptr<Optimizer<T>>(create_optimizer<T>(nested[i])));
-    }
-    m_offsets.emplace_back(m_n_weights);
-    update_hyperparams(params);
-  }
+	public:
+		CompositeOptimizer(const json &params) {
+				if (!params.contains("nested") || !params["nested"].is_array() || params["nested"].empty()) {
+						throw std::runtime_error{"Must provide an array of nested encodings to CompositeOptimizer."};
+				}
+				const json::array_t &nested = params["nested"];
+				m_n_weights = 0;
+				for (size_t i = 0; i < nested.size(); ++i) {
+						m_offsets.emplace_back(m_n_weights);
+						m_n_weights += nested[i].value("n_params_to_optimize", 0);
+						m_nested.emplace_back(std::shared_ptr<Optimizer<T>>(create_optimizer<T>(nested[i])));
+						m_base_learning_rates.emplace_back(m_nested.back()->learning_rate());
+				}
+				m_offsets.emplace_back(m_n_weights);
+				update_hyperparams(params);
+				m_learning_rate_factor = 1.0f;
+		}
 
-  void allocate(uint32_t n_weights, const std::vector<std::pair<uint32_t, uint32_t>>& layer_sizes) override {
-    for (int i = 0; i < m_nested.size(); i++) {
-      uint32_t size = m_offsets[i + 1] - m_offsets[i];
-      m_nested[i]->allocate(size, slice_weights(layer_sizes, m_offsets[i], size));
-      m_need_custom_weights |= m_nested[i]->custom_weights() != nullptr;
-    }
-    if (m_need_custom_weights) {
-      m_custom_weights.resize(m_n_weights);
-    }
-  }
+		void allocate(uint32_t n_weights, const std::vector<std::pair<uint32_t, uint32_t>> &layer_sizes) override {
+				for (int i = 0; i < m_nested.size(); i++) {
+						uint32_t size = m_offsets[i + 1] - m_offsets[i];
+						m_nested[i]->allocate(size, slice_weights(layer_sizes, m_offsets[i], size));
+						m_need_custom_weights |= m_nested[i]->custom_weights() != nullptr;
+				}
+				if (m_need_custom_weights) {
+						m_custom_weights.resize(m_n_weights);
+				}
+		}
 
-  void step(cudaStream_t stream, float loss_scale, float* weights_full_precision, T* weights,
-            const T* gradients) override {
-    for (int i = 0; i < m_nested.size(); i++) {
-      uint32_t offset = m_offsets[i];
-      m_nested[i]->step(stream, loss_scale, weights_full_precision + offset, weights + offset, gradients + offset);
-      if (m_need_custom_weights) {
-        cudaMemcpyAsync(m_custom_weights.data() + offset,
-                        (m_nested[i]->custom_weights() == nullptr ? weights : m_nested[i]->custom_weights()) + offset,
-                        m_nested[i]->n_weights() * sizeof(T), cudaMemcpyDeviceToDevice, stream);
-      }
-    }
-  }
+		void step(cudaStream_t stream, float loss_scale, float *weights_full_precision, T *weights,
+		          const T *gradients) override {
+				for (int i = 0; i < m_nested.size(); i++) {
+						uint32_t offset = m_offsets[i];
+						m_nested[i]->step(stream, loss_scale, weights_full_precision + offset, weights + offset, gradients + offset);
+						if (m_need_custom_weights) {
+								CUDA_CHECK_THROW(cudaMemcpyAsync(
+								    m_custom_weights.data() + offset,
+								    (m_nested[i]->custom_weights() == nullptr ? weights : m_nested[i]->custom_weights()) + offset,
+								    m_nested[i]->n_weights() * sizeof(T), cudaMemcpyDeviceToDevice, stream));
+						}
+				}
+		}
 
-  float learning_rate() const override { return learning_rate_scale; }
+		float learning_rate() const override { return m_learning_rate_factor; }
 
-  void set_learning_rate(float val) override {
-    learning_rate_scale = val;
-    for (int i = 0; i < m_nested.size(); i++) {
-      m_nested[i]->set_learning_rate(m_nested[i]->learning_rate() * learning_rate_scale);
-    }
-  }
+		void set_learning_rate(float val) override {
+				m_learning_rate_factor = val;
+				for (int i = 0; i < m_nested.size(); i++) {
+						m_nested[i]->set_learning_rate(m_base_learning_rates[i] * m_learning_rate_factor);
+				}
+		}
 
-  uint32_t step() const override { return m_nested[0]->step(); }
+		uint32_t step() const override { return m_nested[0]->step(); }
 
-  uint32_t n_weights() const override { return m_n_weights; }
+		uint32_t n_weights() const override { return m_n_weights; }
 
-  T* custom_weights() const override { return m_custom_weights.data(); }
+		T *custom_weights() const override { return m_custom_weights.data(); }
 
-  void update_hyperparams(const json& params) override {
-    if (params.contains("nested") && params["nested"].is_array()) {
-      const json::array_t& nested = params["nested"];
-      for (int i = 0; i < m_nested.size(); i++) {
-        m_nested[i]->update_hyperparams(nested[i]);
-      }
-    }
-    if (params.contains("learning_rate_scale")) {
-      learning_rate_scale = params["learning_rate_scale"];
-    }
-  }
+		void update_hyperparams(const json &params) override {
+				if (params.contains("nested") && params["nested"].is_array()) {
+						const json::array_t &nested = params["nested"];
+						for (int i = 0; i < m_nested.size(); i++) {
+								m_nested[i]->update_hyperparams(nested[i]);
+						}
+				}
+		}
 
-  bool supports_nesting() const override { return true; }
-  uint32_t num_nesting() const { return m_nested.size(); }
-  const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {
-    CHECK_THROW(idx < m_nested.size());
-    return m_nested[idx];
-  }
+		uint32_t n_nesting() const override { return m_nested.size(); }
+		const std::shared_ptr<Optimizer<T>> &nested(uint32_t idx) const override {
+				CHECK_THROW(idx < m_nested.size());
+				return m_nested[idx];
+		}
 
-  json hyperparams() const override {
-    json::array_t nested;
-    for (auto& n : m_nested) {
-      nested.emplace_back(n->hyperparams());
-    }
-    return {{"otype", "Composite"}, {"nested", nested}, {"learning_rate_scale", learning_rate_scale}};
-  }
+		json hyperparams() const override {
+				json::array_t nested;
+				for (auto &n : m_nested) {
+						nested.emplace_back(n->hyperparams());
+				}
+				return {{"otype", "Composite"}, {"nested", nested}};
+		}
 
-  json serialize() const override {
-    json::array_t nested;
-    for (auto& n : m_nested) {
-      nested.emplace_back(n->serialize());
-    }
-    return {{"nested", nested}};
-  }
+		json serialize() const override {
+				json::array_t nested;
+				for (auto &n : m_nested) {
+						nested.emplace_back(n->serialize());
+				}
+				return {{"nested", nested},
+				        {"base_learning_rates", m_base_learning_rates},
+				        {"learning_rate_factor", m_learning_rate_factor}};
+		}
 
-  void deserialize(const json& data) override {
-    const json::array_t& nested = data["nested"];
-    for (int i = 0; i < m_nested.size(); i++) {
-      m_nested[i]->deserialize(nested[i]);
-    }
-    learning_rate_scale = data["learning_rate_scale"];
-  }
+		void deserialize(const json &data) override {
+				const json::array_t &nested = data["nested"];
+				for (int i = 0; i < m_nested.size(); i++) {
+						m_nested.at(i)->deserialize(nested[i]);
+				}
+				data["base_learning_rates"].get_to(m_base_learning_rates);
+				set_learning_rate(data["learning_rate_factor"]);
+		}
 
- private:
-  std::vector<std::shared_ptr<Optimizer<T>>> m_nested;
-  std::vector<uint32_t> m_offsets;
-  uint32_t m_n_weights;
-  float learning_rate_scale = 1.0f;
-  bool m_need_custom_weights = false;
-  GPUMemory<T> m_custom_weights;
+	private:
+		std::vector<std::shared_ptr<Optimizer<T>>> m_nested;
+		std::vector<float> m_base_learning_rates;
+		std::vector<uint32_t> m_offsets;
+		uint32_t m_n_weights;
+		float m_learning_rate_factor;
+		bool m_need_custom_weights = false;
+		GPUMemory<T> m_custom_weights;
 };
 
 TCNN_NAMESPACE_END

--- a/include/tiny-cuda-nn/optimizers/composite.h
+++ b/include/tiny-cuda-nn/optimizers/composite.h
@@ -1,0 +1,157 @@
+/** @file   composite.h
+ *  @author Sergei Solonets, Technical University of Munich
+ *  @brief  Allow using different optimizer on different parameters.
+ */
+
+#pragma once
+
+#include <tiny-cuda-nn/common.h>
+#include <tiny-cuda-nn/gpu_memory.h>
+#include <tiny-cuda-nn/optimizer.h>
+
+#include <stdint.h>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+TCNN_NAMESPACE_BEGIN
+
+/* This class is workaround around current architecture.
+   If this PR is accepted the signature of allocate function could be changed to allocate(uint32 size).
+   Apllying different regularization to encodings and mlp could be instead done using this optimizer
+*/
+template <typename PARAMS_T>
+class ParametricObjectSlice : public ParametricObject<PARAMS_T> {
+ public:
+  ParametricObjectSlice(const ParametricObject<PARAMS_T>& object, uint32_t offset, uint32_t size)
+      : m_offset(offset), m_size(size) {
+    auto object_layer_size = object.layer_sizes();
+    uint32_t current_offset = 0;
+    uint32_t current_layer = 0;
+    while (current_offset < offset && current_layer < object_layer_size.size()) {
+      current_layer++;
+      current_offset += object_layer_size[current_layer].first * object_layer_size[current_layer].second;
+    }
+    if (current_layer < object_layer_size.size() && current_offset != offset) {
+      std::cout << current_offset << " " << offset << " " << current_layer << " " << object_layer_size.size()
+                << std::endl;
+      throw std::runtime_error{"Invalid slice. Can't slice within a layer"};
+    }
+    for (; current_layer < object_layer_size.size(); current_layer++) {
+      m_layer_sizes.emplace_back(object_layer_size[current_layer]);
+    }
+  }
+  void set_params(PARAMS_T* params, PARAMS_T* inference_params, PARAMS_T* backward_params,
+                  PARAMS_T* gradients) override {
+    throw std::runtime_error{"Not implemented"};
+  }
+  void initialize_params(pcg32& rnd, float* params_full_precision, PARAMS_T* params, PARAMS_T* inference_params,
+                         PARAMS_T* backward_params, PARAMS_T* gradients, float scale = 1) override {
+    throw std::runtime_error{"Not implemented"};
+  }
+  size_t n_params() const override { return m_size; }
+
+  std::vector<std::pair<uint32_t, uint32_t>> layer_sizes() const override { return m_layer_sizes; }
+  json hyperparams() const override { return {}; }
+
+ private:
+  uint32_t m_offset;
+  uint32_t m_size;
+  std::vector<std::pair<uint32_t, uint32_t>> m_layer_sizes;
+};
+
+template <typename T>
+class CompositeOptimizer : public Optimizer<T> {
+ public:
+  CompositeOptimizer(const json& params) {
+    if (!params.contains("nested") || !params["nested"].is_array()) {
+      throw std::runtime_error{"Must provide an array of nested encodings to CompositeOptimizer."};
+    }
+    const json::array_t& nested = params["nested"];
+    m_n_weights = 0;
+    for (size_t i = 0; i < nested.size(); ++i) {
+      m_offsets.emplace_back(m_n_weights);
+      m_n_weights += nested[i].value("n_params_to_optimize", 0);
+      m_nested.emplace_back(std::unique_ptr<Optimizer<T>>(create_optimizer<T>(nested[i])));
+    }
+    m_offsets.emplace_back(m_n_weights);
+    update_hyperparams(params);
+  }
+
+  void allocate(std::shared_ptr<ParametricObject<T>> target) override {
+    for (int i = 0; i < m_nested.size(); i++) {
+      uint32_t size = m_offsets[i + 1] - m_offsets[i];
+      auto slice = std::make_shared<ParametricObjectSlice<T>>(*target, m_offsets[i], size);
+      m_nested[i]->allocate(slice);
+    }
+    uint32_t size = (uint32_t)target->n_params();
+  }
+
+  void step(cudaStream_t stream, float loss_scale, float* weights_full_precision, T* weights,
+            const T* gradients) override {
+    for (int i = 0; i < m_nested.size(); i++) {
+      uint32_t offset = m_offsets[i];
+      m_nested[i]->step(stream, loss_scale, weights_full_precision + offset, weights + offset, gradients + offset);
+    }
+  }
+
+  float learning_rate() const override { return learning_rate_scale; }
+
+  void set_learning_rate(float val) override {
+    learning_rate_scale = val;
+    for (int i = 0; i < m_nested.size(); i++) {
+      m_nested[i]->set_learning_rate(m_nested[i]->learning_rate() * learning_rate_scale);
+    }
+  }
+
+  uint32_t step() const override { return m_nested[0]->step(); }
+
+  uint32_t n_weights() const override { return m_n_weights; }
+
+  T* custom_weights() const override { return nullptr; }
+
+  void update_hyperparams(const json& params) override {
+    if (params.contains("nested") && params["nested"].is_array()) {
+      const json::array_t& nested = params["nested"];
+      for (int i = 0; i < m_nested.size(); i++) {
+        m_nested[i]->update_hyperparams(nested[i]);
+      }
+    }
+    if (params.contains("learning_rate_scale")) {
+      learning_rate_scale = params["learning_rate_scale"];
+    }
+  }
+
+  json hyperparams() const override {
+    json::array_t nested;
+    for (auto& n : m_nested) {
+      nested.emplace_back(n->hyperparams());
+    }
+    return {{"otype", "Composite"}, {"nested", nested}, {"learning_rate_scale", learning_rate_scale}};
+  }
+
+  json serialize() const override {
+    json::array_t nested;
+    for (auto& n : m_nested) {
+      nested.emplace_back(n->serialize());
+    }
+    return {{"nested", nested}};
+  }
+
+  void deserialize(const json& data) override {
+    const json::array_t& nested = data["nested"];
+    for (int i = 0; i < m_nested.size(); i++) {
+      m_nested[i]->deserialize(nested[i]);
+    }
+    learning_rate_scale = data["learning_rate_scale"];
+  }
+
+ private:
+  std::vector<std::unique_ptr<Optimizer<T>>> m_nested;
+  std::vector<uint32_t> m_offsets;
+  uint32_t m_n_weights;
+  float learning_rate_scale = 1.0f;
+};
+
+TCNN_NAMESPACE_END

--- a/include/tiny-cuda-nn/optimizers/composite.h
+++ b/include/tiny-cuda-nn/optimizers/composite.h
@@ -5,11 +5,11 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <tiny-cuda-nn/common.h>
 #include <tiny-cuda-nn/gpu_memory.h>
 #include <tiny-cuda-nn/optimizer.h>
 
-#include <stdint.h>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -17,82 +17,65 @@
 
 TCNN_NAMESPACE_BEGIN
 
-/* This class is workaround around current architecture.
-   If this PR is accepted the signature of allocate function could be changed to allocate(uint32 size).
-   Apllying different regularization to encodings and mlp could be instead done using this optimizer
-*/
-template <typename PARAMS_T>
-class ParametricObjectSlice : public ParametricObject<PARAMS_T> {
- public:
-  ParametricObjectSlice(const ParametricObject<PARAMS_T>& object, uint32_t offset, uint32_t size)
-      : m_offset(offset), m_size(size) {
-    auto object_layer_size = object.layer_sizes();
-    uint32_t current_offset = 0;
-    uint32_t current_layer = 0;
-    while (current_offset < offset && current_layer < object_layer_size.size()) {
-      current_layer++;
-      current_offset += object_layer_size[current_layer].first * object_layer_size[current_layer].second;
-    }
-    if (current_layer < object_layer_size.size() && current_offset != offset) {
-      std::cout << current_offset << " " << offset << " " << current_layer << " " << object_layer_size.size()
-                << std::endl;
-      throw std::runtime_error{"Invalid slice. Can't slice within a layer"};
-    }
-    for (; current_layer < object_layer_size.size(); current_layer++) {
-      m_layer_sizes.emplace_back(object_layer_size[current_layer]);
-    }
+std::vector<std::pair<uint32_t, uint32_t>> slice_weights(
+    std::vector<std::pair<uint32_t, uint32_t>> object_layer_size,
+    uint32_t offset, uint32_t size) {
+  std::vector<std::pair<uint32_t, uint32_t>> layer_sizes;
+  uint32_t current_offset = 0;
+  uint32_t current_layer = 0;
+  while (current_offset < offset && current_layer < object_layer_size.size()) {
+    current_layer++;
+    current_offset += object_layer_size[current_layer].first *
+                      object_layer_size[current_layer].second;
   }
-  void set_params(PARAMS_T* params, PARAMS_T* inference_params, PARAMS_T* backward_params,
-                  PARAMS_T* gradients) override {
-    throw std::runtime_error{"Not implemented"};
+  if (current_layer < object_layer_size.size() && current_offset != offset) {
+    std::cout << current_offset << " " << offset << " " << current_layer << " "
+              << object_layer_size.size() << std::endl;
+    throw std::runtime_error{"Invalid slice. Can't slice within a layer"};
   }
-  void initialize_params(pcg32& rnd, float* params_full_precision, PARAMS_T* params, PARAMS_T* inference_params,
-                         PARAMS_T* backward_params, PARAMS_T* gradients, float scale = 1) override {
-    throw std::runtime_error{"Not implemented"};
+  for (; current_layer < object_layer_size.size(); current_layer++) {
+    layer_sizes.emplace_back(object_layer_size[current_layer]);
   }
-  size_t n_params() const override { return m_size; }
-
-  std::vector<std::pair<uint32_t, uint32_t>> layer_sizes() const override { return m_layer_sizes; }
-  json hyperparams() const override { return {}; }
-
- private:
-  uint32_t m_offset;
-  uint32_t m_size;
-  std::vector<std::pair<uint32_t, uint32_t>> m_layer_sizes;
-};
+  return layer_sizes;
+}
 
 template <typename T>
 class CompositeOptimizer : public Optimizer<T> {
  public:
   CompositeOptimizer(const json& params) {
     if (!params.contains("nested") || !params["nested"].is_array()) {
-      throw std::runtime_error{"Must provide an array of nested encodings to CompositeOptimizer."};
+      throw std::runtime_error{
+          "Must provide an array of nested encodings to CompositeOptimizer."};
     }
     const json::array_t& nested = params["nested"];
     m_n_weights = 0;
     for (size_t i = 0; i < nested.size(); ++i) {
       m_offsets.emplace_back(m_n_weights);
       m_n_weights += nested[i].value("n_params_to_optimize", 0);
-      m_nested.emplace_back(std::unique_ptr<Optimizer<T>>(create_optimizer<T>(nested[i])));
+      m_nested.emplace_back(
+          std::shared_ptr<Optimizer<T>>(create_optimizer<T>(nested[i])));
     }
     m_offsets.emplace_back(m_n_weights);
     update_hyperparams(params);
   }
 
-  void allocate(std::shared_ptr<ParametricObject<T>> target) override {
+  void allocate(
+      uint32_t n_weights,
+      const std::vector<std::pair<uint32_t, uint32_t>>& layer_sizes) override {
     for (int i = 0; i < m_nested.size(); i++) {
       uint32_t size = m_offsets[i + 1] - m_offsets[i];
-      auto slice = std::make_shared<ParametricObjectSlice<T>>(*target, m_offsets[i], size);
-      m_nested[i]->allocate(slice);
+      m_nested[i]->allocate(size,
+                            slice_weights(layer_sizes, m_offsets[i], size));
     }
-    uint32_t size = (uint32_t)target->n_params();
   }
 
-  void step(cudaStream_t stream, float loss_scale, float* weights_full_precision, T* weights,
+  void step(cudaStream_t stream, float loss_scale,
+            float* weights_full_precision, T* weights,
             const T* gradients) override {
     for (int i = 0; i < m_nested.size(); i++) {
       uint32_t offset = m_offsets[i];
-      m_nested[i]->step(stream, loss_scale, weights_full_precision + offset, weights + offset, gradients + offset);
+      m_nested[i]->step(stream, loss_scale, weights_full_precision + offset,
+                        weights + offset, gradients + offset);
     }
   }
 
@@ -101,7 +84,8 @@ class CompositeOptimizer : public Optimizer<T> {
   void set_learning_rate(float val) override {
     learning_rate_scale = val;
     for (int i = 0; i < m_nested.size(); i++) {
-      m_nested[i]->set_learning_rate(m_nested[i]->learning_rate() * learning_rate_scale);
+      m_nested[i]->set_learning_rate(m_nested[i]->learning_rate() *
+                                     learning_rate_scale);
     }
   }
 
@@ -123,12 +107,21 @@ class CompositeOptimizer : public Optimizer<T> {
     }
   }
 
+  bool supports_nesting() const override { return true; }
+  uint32_t num_nesting() const { return m_nested.size(); }
+  const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {
+    CHECK_THROW(idx < m_nested.size());
+    return m_nested[idx];
+  }
+
   json hyperparams() const override {
     json::array_t nested;
     for (auto& n : m_nested) {
       nested.emplace_back(n->hyperparams());
     }
-    return {{"otype", "Composite"}, {"nested", nested}, {"learning_rate_scale", learning_rate_scale}};
+    return {{"otype", "Composite"},
+            {"nested", nested},
+            {"learning_rate_scale", learning_rate_scale}};
   }
 
   json serialize() const override {
@@ -148,7 +141,7 @@ class CompositeOptimizer : public Optimizer<T> {
   }
 
  private:
-  std::vector<std::unique_ptr<Optimizer<T>>> m_nested;
+  std::vector<std::shared_ptr<Optimizer<T>>> m_nested;
   std::vector<uint32_t> m_offsets;
   uint32_t m_n_weights;
   float learning_rate_scale = 1.0f;

--- a/include/tiny-cuda-nn/optimizers/ema.h
+++ b/include/tiny-cuda-nn/optimizers/ema.h
@@ -156,9 +156,9 @@ public:
 		return m_weights_ema.data();
 	}
 
-	bool supports_nesting() const override {
-		return true;
-	}
+	uint32_t n_nesting() const override {
+    return 1;
+  }
 
 	const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {
 		CHECK_THROW(idx == 0);

--- a/include/tiny-cuda-nn/optimizers/ema.h
+++ b/include/tiny-cuda-nn/optimizers/ema.h
@@ -160,7 +160,8 @@ public:
 		return true;
 	}
 
-	const std::shared_ptr<Optimizer<T>>& nested() const override {
+	const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {
+		CHECK_THROW(idx == 0);
 		return m_nested;
 	}
 

--- a/include/tiny-cuda-nn/optimizers/exponential_decay.h
+++ b/include/tiny-cuda-nn/optimizers/exponential_decay.h
@@ -92,8 +92,8 @@ public:
 		return m_nested->custom_weights();
 	}
 
-	bool supports_nesting() const override {
-		return true;
+	uint32_t n_nesting() const override {
+		return 1;
 	}
 
 	const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {

--- a/include/tiny-cuda-nn/optimizers/exponential_decay.h
+++ b/include/tiny-cuda-nn/optimizers/exponential_decay.h
@@ -96,7 +96,8 @@ public:
 		return true;
 	}
 
-	const std::shared_ptr<Optimizer<T>>& nested() const override {
+	const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {
+		CHECK_THROW(idx == 0);
 		return m_nested;
 	}
 

--- a/include/tiny-cuda-nn/optimizers/lookahead.h
+++ b/include/tiny-cuda-nn/optimizers/lookahead.h
@@ -120,7 +120,8 @@ public:
 		return true;
 	}
 
-	const std::shared_ptr<Optimizer<T>>& nested() const override {
+	const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {
+		CHECK_THROW(idx == 0);
 		return m_nested;
 	}
 

--- a/include/tiny-cuda-nn/optimizers/lookahead.h
+++ b/include/tiny-cuda-nn/optimizers/lookahead.h
@@ -116,8 +116,8 @@ public:
 		return m_weights_lookahead.data();
 	}
 
-	bool supports_nesting() const override {
-		return true;
+	uint32_t n_nesting() const override {
+		return 1;
 	}
 
 	const std::shared_ptr<Optimizer<T>>& nested(uint32_t idx) const override {

--- a/include/tiny-cuda-nn/optimizers/novograd.h
+++ b/include/tiny-cuda-nn/optimizers/novograd.h
@@ -186,8 +186,8 @@ public:
 		return nullptr;
 	}
 
-	bool supports_nesting() const override {
-		return false;
+	uint32_t n_nesting() const override {
+		return 0;
 	}
 
 	void update_hyperparams(const json& params) override {

--- a/include/tiny-cuda-nn/optimizers/sgd.h
+++ b/include/tiny-cuda-nn/optimizers/sgd.h
@@ -114,8 +114,8 @@ public:
 		return nullptr;
 	}
 
-	bool supports_nesting() const override {
-		return false;
+	uint32_t n_nesting() const override {
+		return 0;
 	}
 
 	void update_hyperparams(const json& params) override {

--- a/include/tiny-cuda-nn/optimizers/shampoo.h
+++ b/include/tiny-cuda-nn/optimizers/shampoo.h
@@ -914,8 +914,8 @@ public:
 		return nullptr;
 	}
 
-	bool supports_nesting() const override {
-		return false;
+	uint32_t n_nesting() const override {
+		return 0;
 	}
 
 	void update_hyperparams(const json& params) override {

--- a/src/optimizer.cu
+++ b/src/optimizer.cu
@@ -57,6 +57,8 @@ Optimizer<T>* create_optimizer(const json& optimizer) {
 		return new AverageOptimizer<T>{optimizer};
 	} else if (equals_case_insensitive(optimizer_type, "Batched")) {
 		return new BatchedOptimizer<T>{optimizer};
+	} else if (equals_case_insensitive(optimizer_type, "Composite")) {
+		return new CompositeOptimizer<T>{optimizer};
 	} else if (equals_case_insensitive(optimizer_type, "Ema")) {
 		return new EmaOptimizer<T>{optimizer};
 	} else if (equals_case_insensitive(optimizer_type, "ExponentialDecay")) {
@@ -73,8 +75,6 @@ Optimizer<T>* create_optimizer(const json& optimizer) {
 #else
 		throw std::runtime_error{"The Shampoo optimizer is only available when compiling with CUDA 11 or higher."};
 #endif
-	} else if (equals_case_insensitive(optimizer_type, "Composite")) {
-    	return new CompositeOptimizer<T>{optimizer};
 	} else {
 		throw std::runtime_error{fmt::format("Invalid optimizer type: {}", optimizer_type)};
 	}

--- a/src/optimizer.cu
+++ b/src/optimizer.cu
@@ -34,6 +34,7 @@
 #include <tiny-cuda-nn/optimizers/average.h>
 #include <tiny-cuda-nn/optimizers/batched.h>
 #include <tiny-cuda-nn/optimizers/ema.h>
+#include <tiny-cuda-nn/optimizers/composite.h>
 #include <tiny-cuda-nn/optimizers/exponential_decay.h>
 #include <tiny-cuda-nn/optimizers/lookahead.h>
 #include <tiny-cuda-nn/optimizers/novograd.h>
@@ -72,6 +73,8 @@ Optimizer<T>* create_optimizer(const json& optimizer) {
 #else
 		throw std::runtime_error{"The Shampoo optimizer is only available when compiling with CUDA 11 or higher."};
 #endif
+	} else if (equals_case_insensitive(optimizer_type, "Composite")) {
+    	return new CompositeOptimizer<T>{optimizer};
 	} else {
 		throw std::runtime_error{fmt::format("Invalid optimizer type: {}", optimizer_type)};
 	}


### PR DESCRIPTION
Hi Tom, 

While using your lib I needed to stick 2 networks with input encodings sequentially. Apparently, I can only do it now it float precision. I changed the code a bit to allow NetworkWithInputEncdoings also admit half precision. Do you think it'd be a sound thing to change or I am getting something wrong in the design?

I changed the code based on my previous pr since it introduces some changes to it as well. I can modify this pr after the first one is accepted or rejected. Meanwhile, you can take a look at the diff here https://github.com/Solonets/tiny-cuda-nn/pull/1 .

I also didn't change HashGrid encodings to work with half precision. It looks like it's a bit more involved as some numeric issues can arise there. But I could also try to change it as well.

 