### PR TITLE
Fix use-after-free during program exit

### DIFF
--- a/include/tiny-cuda-nn/gpu_memory.h
+++ b/include/tiny-cuda-nn/gpu_memory.h
@@ -696,9 +696,15 @@ private:
 	size_t m_max_size;
 };
 
-// Defined in common.cu to facilitate ordered destruction upon program exit.
-std::unordered_map<cudaStream_t, std::shared_ptr<GPUMemoryArena>>& stream_gpu_memory_arenas();
-std::unordered_map<int, std::shared_ptr<GPUMemoryArena>>& global_gpu_memory_arenas();
+inline std::unordered_map<cudaStream_t, std::shared_ptr<GPUMemoryArena>>& stream_gpu_memory_arenas() {
+	static auto* stream_gpu_memory_arenas = new std::unordered_map<cudaStream_t, std::shared_ptr<GPUMemoryArena>>{};
+	return *stream_gpu_memory_arenas;
+}
+
+inline std::unordered_map<int, std::shared_ptr<GPUMemoryArena>>& global_gpu_memory_arenas() {
+	static auto* global_gpu_memory_arenas = new std::unordered_map<int, std::shared_ptr<GPUMemoryArena>>{};
+	return *global_gpu_memory_arenas;
+}
 
 inline GPUMemoryArena::Allocation allocate_workspace(cudaStream_t stream, size_t n_bytes) {
 	if (n_bytes == 0) {

--- a/include/tiny-cuda-nn/multi_stream.h
+++ b/include/tiny-cuda-nn/multi_stream.h
@@ -142,9 +142,15 @@ private:
 	cudaEvent_t m_event;
 };
 
-// Defined in common.cu to facilitate ordered destruction upon program exit.
-std::unordered_map<cudaStream_t, std::stack<std::shared_ptr<MultiStream>>>& stream_multi_streams();
-std::unordered_map<int, std::stack<std::shared_ptr<MultiStream>>>& global_multi_streams();
+inline std::unordered_map<cudaStream_t, std::stack<std::shared_ptr<MultiStream>>>& stream_multi_streams() {
+	static auto* stream_multi_streams = new std::unordered_map<cudaStream_t, std::stack<std::shared_ptr<MultiStream>>>{};
+	return *stream_multi_streams;
+}
+
+inline std::unordered_map<int, std::stack<std::shared_ptr<MultiStream>>>& global_multi_streams() {
+	static auto* global_multi_streams = new std::unordered_map<int, std::stack<std::shared_ptr<MultiStream>>>{};
+	return *global_multi_streams;
+}
 
 inline std::stack<std::shared_ptr<MultiStream>>& get_multi_stream_stack(cudaStream_t parent_stream) {
 	return parent_stream ? stream_multi_streams()[parent_stream] : global_multi_streams()[cuda_device()];


### PR DESCRIPTION
Singleton destruction order prevents an orderly shutdown of stream-associated objects. This commit works around the issue by allocating stream-associated singletons on the heap and letting the OS clean them up after program exit.

Fixes #159 