### PR TITLE
Bypass null tensor when doing double differentiation for PyTorch < 1.10 and tiny-cuda-nn >= 1.5

### DIFF
--- a/bindings/torch/tinycudann/modules.py
+++ b/bindings/torch/tinycudann/modules.py
@@ -47,6 +47,14 @@ def free_temporary_memory():
 	gc.collect()
 	_C.free_temporary_memory()
 
+def null_as(tensor):
+	return torch.empty([], dtype=tensor.dtype, device=tensor.device)
+
+def maybe_null_tensor_to_none(tensor_to_convert, should_be_converted):
+	if should_be_converted:
+		return None
+	return tensor_to_convert
+
 class _module_function(torch.autograd.Function):
 	@staticmethod
 	def forward(ctx, native_tcnn_module, input, params, loss_scale):
@@ -74,6 +82,9 @@ class _module_function(torch.autograd.Function):
 		input, params, output = ctx.saved_tensors
 		input_grad, weight_grad = _module_function_backward.apply(ctx, doutput, input, params, output)
 
+		input_grad = maybe_null_tensor_to_none(input_grad, input.requires_grad)
+		weight_grad = maybe_null_tensor_to_none(weight_grad, params.requires_grad)
+
 		return None, input_grad, weight_grad, None
 
 class _module_function_backward(torch.autograd.Function):
@@ -84,8 +95,8 @@ class _module_function_backward(torch.autograd.Function):
 		with torch.no_grad():
 			scaled_grad = doutput * ctx_fwd.loss_scale
 			input_grad, weight_grad = ctx_fwd.native_tcnn_module.bwd(ctx_fwd.native_ctx, input, params, output, scaled_grad)
-			input_grad = None if input_grad is None else (input_grad / ctx_fwd.loss_scale)
-			weight_grad = None if weight_grad is None else (weight_grad / ctx_fwd.loss_scale)
+			input_grad = null_as(input_grad) if input_grad is None else (input_grad / ctx_fwd.loss_scale)
+			weight_grad = null_as(input_grad) if weight_grad is None else (weight_grad / ctx_fwd.loss_scale)
 		return input_grad, weight_grad
 
 	@staticmethod
@@ -112,8 +123,8 @@ class _module_function_backward(torch.autograd.Function):
 			#       doutput_grad uses dinput_grad
 			#       weight_grad  uses dinput_grad * doutput
 			#       input_grad   uses dinput_grad * doutput
-			weight_grad = None if weight_grad is None else (weight_grad / ctx.ctx_fwd.loss_scale)
-			input_grad = None if input_grad is None else (input_grad / ctx.ctx_fwd.loss_scale)
+			weight_grad = null_as(weight_grad) if weight_grad is None else (weight_grad / ctx.ctx_fwd.loss_scale)
+			input_grad = null_as(input_grad) if input_grad is None else (input_grad / ctx.ctx_fwd.loss_scale)
 
 		# ctx_fwd,   doutput,      input,      params,      output
 		return None, doutput_grad, input_grad, weight_grad, None


### PR DESCRIPTION
The case is necessary because PyTorch < 1.10 and tiny-cuda-nn >= 1.5 cannot handle returning None values when doing second-order differentiation. To bypass it, create an empty tensor first, and then by checking if the tensor requires grad, convert the empty tensor into the `None` value.

Solves the initial problem in: #84 , and potential problems in: #204 