### PR TITLE
Overhaul parameter init

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -37,8 +37,6 @@ Lightning fast implementation of small multi-layer perceptrons (MLPs). Restricte
 	"n_neurons": 128,            // Neurons in each hidden layer.
 	                             // May only be 16, 32, 64, or 128.
 	"n_hidden_layers": 5,        // Number of hidden layers.
-	"feedback_alignment": false  // Use feedback alignment
-	                             // [Lillicrap et al. 2016].
 }
 ```
 

--- a/include/tiny-cuda-nn/cpp_api.h
+++ b/include/tiny-cuda-nn/cpp_api.h
@@ -86,7 +86,7 @@ public:
 		return m_param_precision;
 	}
 
-	virtual void initialize_params(size_t seed, float* params_full_precision) = 0;
+	virtual void initialize_params(size_t seed, float* params_full_precision, float scale = 1.0f) = 0;
 
 	virtual uint32_t n_output_dims() const = 0;
 	EPrecision output_precision() const {

--- a/include/tiny-cuda-nn/encoding.h
+++ b/include/tiny-cuda-nn/encoding.h
@@ -76,8 +76,8 @@ public:
 	virtual MatrixLayout preferred_output_layout() const = 0;
 
 	// By default, an encoding has no parameters
-	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override { }
-	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override { }
+	void set_params_impl(T* params, T* inference_params, T* gradients) override { }
+	void initialize_params(pcg32& rnd, float* params_full_precision, float scale = 1) override { }
 	size_t n_params() const override { return 0; }
 
 	std::vector<std::pair<uint32_t, uint32_t>> layer_sizes() const override { return {}; }

--- a/include/tiny-cuda-nn/encodings/composite.h
+++ b/include/tiny-cuda-nn/encodings/composite.h
@@ -403,32 +403,18 @@ public:
 		return m_nested.empty() ? AoS : m_nested.front()->preferred_output_layout();
 	}
 
-	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override {
+	void set_params_impl(T* params, T* inference_params, T* gradients) override {
 		size_t offset = 0;
 		for (auto& nested : m_nested) {
-			nested->set_params(
-				params + offset,
-				inference_params + offset,
-				backward_params + offset,
-				gradients + offset
-			);
+			nested->set_params(params + offset, inference_params + offset, gradients + offset);
 			offset += nested->n_params();
 		}
 	}
 
-	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override {
-		size_t offset = 0;
+	void initialize_params(pcg32& rnd, float* params_full_precision, float scale = 1) override {
 		for (auto& nested : m_nested) {
-			nested->initialize_params(
-				rnd,
-				params_full_precision + offset,
-				params + offset,
-				inference_params + offset,
-				backward_params + offset,
-				gradients + offset,
-				scale
-			);
-			offset += nested->n_params();
+			nested->initialize_params(rnd, params_full_precision, scale);
+			params_full_precision += nested->n_params();
 		}
 	}
 

--- a/include/tiny-cuda-nn/encodings/grid.h
+++ b/include/tiny-cuda-nn/encodings/grid.h
@@ -1079,7 +1079,7 @@ public:
 			this->m_max_level_gpu,
 			m_interpolation_type,
 			m_grid_type,
-			use_inference_params ? inference_params() : params(),
+			use_inference_params ? this->inference_params() : this->params(),
 			forward->positions.data() ? forward->positions.view() : input.view(),
 			encoded_positions_soa,
 			forward->dy_dx.data()
@@ -1144,7 +1144,7 @@ public:
 				grid_gradient_tmp = allocate_workspace(stream, m_n_params * sizeof(grad_t));
 				grid_gradient = (grad_t*)grid_gradient_tmp.data();
 			} else {
-				grid_gradient = (grad_t*)gradients();
+				grid_gradient = (grad_t*)this->gradients();
 			}
 
 			if (param_gradients_mode == EGradientMode::Overwrite) {
@@ -1173,7 +1173,7 @@ public:
 			);
 
 			if (!std::is_same<grad_t, T>::value) {
-				parallel_for_gpu(stream, n_params(), [grad=gradients(), grad_tmp=grid_gradient] __device__ (size_t i) {
+				parallel_for_gpu(stream, n_params(), [grad=this->gradients(), grad_tmp=grid_gradient] __device__ (size_t i) {
 					grad[i] = (T)grad_tmp[i];
 				});
 			}
@@ -1238,7 +1238,7 @@ public:
 				grid_gradient_tmp = allocate_workspace(stream, m_n_params * sizeof(grad_t));
 				grid_gradient = (grad_t*)grid_gradient_tmp.data();
 			} else {
-				grid_gradient = (grad_t*)gradients();
+				grid_gradient = (grad_t*)this->gradients();
 			}
 
 			if (param_gradients_mode == EGradientMode::Overwrite) {
@@ -1270,7 +1270,7 @@ public:
 			);
 
 			if (!std::is_same<grad_t, T>::value) {
-				parallel_for_gpu(stream, n_params(), [grad=gradients(), grad_tmp=grid_gradient] __device__ (size_t i) {
+				parallel_for_gpu(stream, n_params(), [grad=this->gradients(), grad_tmp=grid_gradient] __device__ (size_t i) {
 					grad[i] = (T)grad_tmp[i];
 				});
 			}
@@ -1312,7 +1312,7 @@ public:
 				dL_ddLdinput.view(),
 				forward.positions.data() ? forward.positions.view() : input.view(),
 				dL_dy_rm,
-				use_inference_params ? inference_params() : params(),
+				use_inference_params ? this->inference_params() : this->params(),
 				// outputs
 				dL_dinput->view()
 			);

--- a/include/tiny-cuda-nn/encodings/grid.h
+++ b/include/tiny-cuda-nn/encodings/grid.h
@@ -1079,7 +1079,7 @@ public:
 			this->m_max_level_gpu,
 			m_interpolation_type,
 			m_grid_type,
-			use_inference_params ? m_grid_inference : m_grid,
+			use_inference_params ? inference_params() : params(),
 			forward->positions.data() ? forward->positions.view() : input.view(),
 			encoded_positions_soa,
 			forward->dy_dx.data()
@@ -1144,7 +1144,7 @@ public:
 				grid_gradient_tmp = allocate_workspace(stream, m_n_params * sizeof(grad_t));
 				grid_gradient = (grad_t*)grid_gradient_tmp.data();
 			} else {
-				grid_gradient = (grad_t*)m_grid_gradient;
+				grid_gradient = (grad_t*)gradients();
 			}
 
 			if (param_gradients_mode == EGradientMode::Overwrite) {
@@ -1173,7 +1173,7 @@ public:
 			);
 
 			if (!std::is_same<grad_t, T>::value) {
-				parallel_for_gpu(stream, n_params(), [grad=m_grid_gradient, grad_tmp=grid_gradient] __device__ (size_t i) {
+				parallel_for_gpu(stream, n_params(), [grad=gradients(), grad_tmp=grid_gradient] __device__ (size_t i) {
 					grad[i] = (T)grad_tmp[i];
 				});
 			}
@@ -1238,7 +1238,7 @@ public:
 				grid_gradient_tmp = allocate_workspace(stream, m_n_params * sizeof(grad_t));
 				grid_gradient = (grad_t*)grid_gradient_tmp.data();
 			} else {
-				grid_gradient = (grad_t*)m_grid_gradient;
+				grid_gradient = (grad_t*)gradients();
 			}
 
 			if (param_gradients_mode == EGradientMode::Overwrite) {
@@ -1270,7 +1270,7 @@ public:
 			);
 
 			if (!std::is_same<grad_t, T>::value) {
-				parallel_for_gpu(stream, n_params(), [grad=m_grid_gradient, grad_tmp=grid_gradient] __device__ (size_t i) {
+				parallel_for_gpu(stream, n_params(), [grad=gradients(), grad_tmp=grid_gradient] __device__ (size_t i) {
 					grad[i] = (T)grad_tmp[i];
 				});
 			}
@@ -1312,7 +1312,7 @@ public:
 				dL_ddLdinput.view(),
 				forward.positions.data() ? forward.positions.view() : input.view(),
 				dL_dy_rm,
-				use_inference_params ? m_grid_inference : m_grid,
+				use_inference_params ? inference_params() : params(),
 				// outputs
 				dL_dinput->view()
 			);
@@ -1348,17 +1348,11 @@ public:
 		return SoA;
 	}
 
-	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override {
-		m_grid = params;
-		m_grid_inference = inference_params;
-		m_grid_gradient = gradients;
-	}
+	void set_params_impl(T* params, T* inference_params, T* gradients) override { }
 
-	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override {
-		set_params(params, inference_params, backward_params, gradients);
-
+	void initialize_params(pcg32& rnd, float* params_full_precision, float scale = 1) override {
 		// Initialize the hashgrid from the GPU, because the number of parameters can be quite large.
-		generate_random_uniform<float>(rnd, n_params(), params_full_precision, -1e-4f, 1e-4f);
+		generate_random_uniform<float>(rnd, n_params(), params_full_precision, -1e-4f * scale, 1e-4f * scale);
 	}
 
 	size_t n_params() const override {
@@ -1434,11 +1428,6 @@ private:
 	bool m_stochastic_interpolation;
 	InterpolationType m_interpolation_type;
 	GridType m_grid_type;
-
-	// Storage of params
-	T* m_grid;
-	T* m_grid_inference;
-	T* m_grid_gradient;
 };
 
 template <typename T, uint32_t N_FEATURES_PER_LEVEL, HashType HASH_TYPE>

--- a/include/tiny-cuda-nn/network.h
+++ b/include/tiny-cuda-nn/network.h
@@ -34,12 +34,6 @@
 
 TCNN_NAMESPACE_BEGIN
 
-enum class WeightUsage {
-	Inference,
-	Forward,
-	Backward,
-};
-
 Activation string_to_activation(const std::string& activation_name);
 std::string to_string(Activation activation);
 

--- a/include/tiny-cuda-nn/network_with_input_encoding.h
+++ b/include/tiny-cuda-nn/network_with_input_encoding.h
@@ -110,48 +110,21 @@ public:
 		}
 	}
 
-	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override {
+	void set_params_impl(T* params, T* inference_params, T* gradients) override {
 		size_t offset = 0;
-		m_network->set_params(
-			params + offset,
-			inference_params + offset,
-			backward_params + offset,
-			gradients + offset
-		);
+		m_network->set_params(params + offset, inference_params + offset, gradients + offset);
 		offset += m_network->n_params();
 
-		m_encoding->set_params(
-			params + offset,
-			inference_params + offset,
-			backward_params + offset,
-			gradients + offset
-		);
+		m_encoding->set_params(params + offset, inference_params + offset, gradients + offset);
 		offset += m_encoding->n_params();
 	}
 
-	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override {
-		size_t offset = 0;
-		m_network->initialize_params(
-			rnd,
-			params_full_precision + offset,
-			params + offset,
-			inference_params + offset,
-			backward_params + offset,
-			gradients + offset,
-			scale
-		);
-		offset += m_network->n_params();
+	void initialize_params(pcg32& rnd, float* params_full_precision, float scale = 1) override {
+		m_network->initialize_params(rnd, params_full_precision, scale);
+		params_full_precision += m_network->n_params();
 
-		m_encoding->initialize_params(
-			rnd,
-			params_full_precision + offset,
-			params + offset,
-			inference_params + offset,
-			backward_params + offset,
-			gradients + offset,
-			scale
-		);
-		offset += m_encoding->n_params();
+		m_encoding->initialize_params(rnd, params_full_precision, scale);
+		params_full_precision += m_encoding->n_params();
 	}
 
 	size_t n_params() const override {

--- a/include/tiny-cuda-nn/networks/cutlass_mlp.h
+++ b/include/tiny-cuda-nn/networks/cutlass_mlp.h
@@ -66,8 +66,8 @@ public:
 		EGradientMode param_gradients_mode = EGradientMode::Overwrite
 	) override;
 
-	void set_params(T* params, T* inference_params, T* backward_params, T* gradients) override;
-	void initialize_params(pcg32& rnd, float* params_full_precision, T* params, T* inference_params, T* backward_params, T* gradients, float scale = 1) override;
+	void set_params_impl(T* params, T* inference_params, T* gradients) override;
+	void initialize_params(pcg32& rnd, float* params_full_precision, float scale = 1) override;
 
 	GPUMatrix<T, RM>& input_weight_matrix(bool inference) {
 		auto& weight_matrices = inference ? m_weight_matrices_inference : m_weight_matrices;

--- a/include/tiny-cuda-nn/object.h
+++ b/include/tiny-cuda-nn/object.h
@@ -65,11 +65,42 @@ class ParametricObject : public Object {
 public:
 	virtual ~ParametricObject() { }
 
-	virtual void set_params(PARAMS_T* params, PARAMS_T* inference_params, PARAMS_T* backward_params, PARAMS_T* gradients) = 0;
-	virtual void initialize_params(pcg32& rnd, float* params_full_precision, PARAMS_T* params, PARAMS_T* inference_params, PARAMS_T* backward_params, PARAMS_T* gradients, float scale = 1) = 0;
+	virtual void set_params_impl(PARAMS_T* params, PARAMS_T* inference_params, PARAMS_T* gradients) = 0;
+
+	// Must be called prior to inference or training use of the parametric object. Each parameter
+	// must point to GPU memory that holds `n_params()` elements.
+	// `params` and `inference_params` may point to the same memory.
+	void set_params(PARAMS_T* params, PARAMS_T* inference_params, PARAMS_T* gradients) {
+		m_params = params;
+		m_inference_params = inference_params;
+		m_gradients = gradients;
+
+		set_params_impl(params, inference_params, gradients);
+	}
+
+	// Initializes the GPU memory addressed by `params_full_precision`. Must hold `n_params()` elements.
+	virtual void initialize_params(pcg32& rnd, float* params_full_precision, float scale = 1) = 0;
+
 	virtual size_t n_params() const = 0;
 
+	PARAMS_T* params() const {
+		return m_params;
+	}
+
+	PARAMS_T* inference_params() const {
+		return m_inference_params;
+	}
+
+	PARAMS_T* gradients() const {
+		return m_gradients;
+	}
+
 	virtual std::vector<std::pair<uint32_t, uint32_t>> layer_sizes() const = 0;
+
+private:
+	PARAMS_T* m_params = nullptr;
+	PARAMS_T* m_inference_params = nullptr;
+	PARAMS_T* m_gradients = nullptr;
 };
 
 template <typename T>
@@ -99,6 +130,14 @@ public:
 		CHECK_THROW(input.n() % batch_size_granularity == 0);
 		CHECK_THROW(input.n() == output.n());
 
+		if (n_params() > 0) {
+			if (use_inference_params) {
+				CHECK_THROW(inference_params() != nullptr);
+			} else {
+				CHECK_THROW(params() != nullptr);
+			}
+		}
+
 		inference_mixed_precision_impl(stream, input, output, use_inference_params);
 	}
 	void inference_mixed_precision(const GPUMatrixDynamic<T>& input, GPUMatrixDynamic<COMPUTE_T>& output, bool use_inference_params = true) {
@@ -110,6 +149,7 @@ public:
 		CHECK_THROW(output.m() == output_width());
 		CHECK_THROW(input.n() % batch_size_granularity == 0);
 		CHECK_THROW(input.n() == output.n());
+		CHECK_THROW(n_params() == 0 || inference_params() != nullptr);
 
 		GPUMatrixDynamic<COMPUTE_T> inference_output_tmp;
 		if (std::is_same<COMPUTE_T, float>::value && padded_output_width() == output_width()) {
@@ -150,6 +190,14 @@ public:
 		CHECK_THROW(!output || output->m() == padded_output_width());
 		CHECK_THROW(input.n() % batch_size_granularity == 0);
 		CHECK_THROW(!output || input.n() == output->n());
+
+		if (n_params() > 0) {
+			if (use_inference_params) {
+				CHECK_THROW(inference_params() != nullptr);
+			} else {
+				CHECK_THROW(params() != nullptr);
+			}
+		}
 
 		return forward_impl(stream, input, output, use_inference_params, prepare_input_gradients);
 	}
@@ -193,6 +241,19 @@ public:
 		CHECK_THROW(input.n() == output.n());
 		CHECK_THROW(input.n() == dL_doutput.n());
 		CHECK_THROW(!dL_dinput || input.n() == dL_dinput->n());
+
+		// Param & gradient memory must have been set via `set_params(...)`
+		if (n_params() > 0) {
+			if (use_inference_params) {
+				CHECK_THROW(inference_params() != nullptr);
+			} else {
+				CHECK_THROW(params() != nullptr);
+			}
+
+			if (param_gradients_mode != EGradientMode::Ignore) {
+				CHECK_THROW(gradients() != nullptr);
+			}
+		}
 
 		backward_impl(stream, ctx, input, output, dL_doutput, dL_dinput, use_inference_params, param_gradients_mode);
 	}
@@ -243,6 +304,19 @@ public:
 		CHECK_THROW(input.n() == dL_doutput.n());
 		CHECK_THROW(!dL_ddLdoutput || input.n() == dL_ddLdoutput->n());
 		CHECK_THROW(!dL_dinput || input.n() == dL_dinput->n());
+
+		// Param & gradient memory must have been set via `set_params(...)`
+		if (n_params() > 0) {
+			if (use_inference_params) {
+				CHECK_THROW(inference_params() != nullptr);
+			} else {
+				CHECK_THROW(params() != nullptr);
+			}
+
+			if (param_gradients_mode != EGradientMode::Ignore) {
+				CHECK_THROW(gradients() != nullptr);
+			}
+		}
 
 		backward_backward_input_impl(stream, ctx, input, dL_ddLdinput, dL_doutput, dL_ddLdoutput, dL_dinput, use_inference_params, param_gradients_mode);
 	}

--- a/include/tiny-cuda-nn/object.h
+++ b/include/tiny-cuda-nn/object.h
@@ -130,11 +130,11 @@ public:
 		CHECK_THROW(input.n() % batch_size_granularity == 0);
 		CHECK_THROW(input.n() == output.n());
 
-		if (n_params() > 0) {
+		if (this->n_params() > 0) {
 			if (use_inference_params) {
-				CHECK_THROW(inference_params() != nullptr);
+				CHECK_THROW(this->inference_params() != nullptr);
 			} else {
-				CHECK_THROW(params() != nullptr);
+				CHECK_THROW(this->params() != nullptr);
 			}
 		}
 
@@ -149,7 +149,7 @@ public:
 		CHECK_THROW(output.m() == output_width());
 		CHECK_THROW(input.n() % batch_size_granularity == 0);
 		CHECK_THROW(input.n() == output.n());
-		CHECK_THROW(n_params() == 0 || inference_params() != nullptr);
+		CHECK_THROW(this->n_params() == 0 || this->inference_params() != nullptr);
 
 		GPUMatrixDynamic<COMPUTE_T> inference_output_tmp;
 		if (std::is_same<COMPUTE_T, float>::value && padded_output_width() == output_width()) {
@@ -191,11 +191,11 @@ public:
 		CHECK_THROW(input.n() % batch_size_granularity == 0);
 		CHECK_THROW(!output || input.n() == output->n());
 
-		if (n_params() > 0) {
+		if (this->n_params() > 0) {
 			if (use_inference_params) {
-				CHECK_THROW(inference_params() != nullptr);
+				CHECK_THROW(this->inference_params() != nullptr);
 			} else {
-				CHECK_THROW(params() != nullptr);
+				CHECK_THROW(this->params() != nullptr);
 			}
 		}
 
@@ -243,15 +243,15 @@ public:
 		CHECK_THROW(!dL_dinput || input.n() == dL_dinput->n());
 
 		// Param & gradient memory must have been set via `set_params(...)`
-		if (n_params() > 0) {
+		if (this->n_params() > 0) {
 			if (use_inference_params) {
-				CHECK_THROW(inference_params() != nullptr);
+				CHECK_THROW(this->inference_params() != nullptr);
 			} else {
-				CHECK_THROW(params() != nullptr);
+				CHECK_THROW(this->params() != nullptr);
 			}
 
 			if (param_gradients_mode != EGradientMode::Ignore) {
-				CHECK_THROW(gradients() != nullptr);
+				CHECK_THROW(this->gradients() != nullptr);
 			}
 		}
 
@@ -306,15 +306,15 @@ public:
 		CHECK_THROW(!dL_dinput || input.n() == dL_dinput->n());
 
 		// Param & gradient memory must have been set via `set_params(...)`
-		if (n_params() > 0) {
+		if (this->n_params() > 0) {
 			if (use_inference_params) {
-				CHECK_THROW(inference_params() != nullptr);
+				CHECK_THROW(this->inference_params() != nullptr);
 			} else {
-				CHECK_THROW(params() != nullptr);
+				CHECK_THROW(this->params() != nullptr);
 			}
 
 			if (param_gradients_mode != EGradientMode::Ignore) {
-				CHECK_THROW(gradients() != nullptr);
+				CHECK_THROW(this->gradients() != nullptr);
 			}
 		}
 

--- a/scripts/test_grid_bwdbwd.py
+++ b/scripts/test_grid_bwdbwd.py
@@ -221,7 +221,6 @@ if __name__ == '__main__':
 			"output_activation": 'None',   # Activation of the output layer.
 			"n_neurons": 64,           # Neurons in each hidden layer. # May only be 16, 32, 64, or 128.
 			"n_hidden_layers": 5,   # Number of hidden layers.
-			"feedback_alignment": False  # Use feedback alignment # [Lillicrap et al. 2016].
 		}, seed=42)
 
 

--- a/scripts/test_random_input.py
+++ b/scripts/test_random_input.py
@@ -24,7 +24,6 @@ class TcnnFCBlock(tcnn.Network):
 			"output_activation": last_activation,   # Activation of the output layer.
 			"n_neurons": hidden_features,           # Neurons in each hidden layer. # May only be 16, 32, 64, or 128.
 			"n_hidden_layers": num_hidden_layers,   # Number of hidden layers.
-			"feedback_alignment": False  # Use feedback alignment # [Lillicrap et al. 2016].
 		}, seed=seed)
 
 	def forward(self, x: torch.Tensor):

--- a/src/cpp_api.cu
+++ b/src/cpp_api.cu
@@ -71,7 +71,7 @@ public:
 	{}
 
 	void inference(cudaStream_t stream, uint32_t n_elements, const float* input, void* output, void* params) override {
-		m_model->set_params((T*)params, (T*)params, nullptr, nullptr);
+		m_model->set_params((T*)params, (T*)params, nullptr);
 
 		GPUMatrix<float, MatrixLayout::ColumnMajor> input_matrix((float*)input, m_model->input_width(), n_elements);
 		GPUMatrix<T, MatrixLayout::ColumnMajor> output_matrix((T*)output, m_model->padded_output_width(), n_elements);
@@ -83,7 +83,7 @@ public:
 	}
 
 	Context forward(cudaStream_t stream, uint32_t n_elements, const float* input, void* output, void* params, bool prepare_input_gradients) override {
-		m_model->set_params((T*)params, (T*)params, nullptr, nullptr);
+		m_model->set_params((T*)params, (T*)params, nullptr);
 
 		GPUMatrix<float, MatrixLayout::ColumnMajor> input_matrix((float*)input, m_model->input_width(), n_elements);
 		GPUMatrix<T, MatrixLayout::ColumnMajor> output_matrix((T*)output, m_model->padded_output_width(), n_elements);
@@ -95,7 +95,7 @@ public:
 	}
 
 	void backward(cudaStream_t stream, const Context& ctx, uint32_t n_elements, float* dL_dinput, const void* dL_doutput, void* dL_dparams, const float* input, const void* output, const void* params) override {
-		m_model->set_params((T*)params, (T*)params, (T*)params, (T*)dL_dparams);
+		m_model->set_params((T*)params, (T*)params, (T*)dL_dparams);
 
 		GPUMatrix<float, MatrixLayout::ColumnMajor> input_matrix((float*)input, m_model->input_width(), n_elements);
 		GPUMatrix<float, MatrixLayout::ColumnMajor> dL_dinput_matrix(dL_dinput, m_model->input_width(), n_elements);
@@ -112,7 +112,7 @@ public:
 	void backward_backward_input(cudaStream_t stream, const Context& ctx, uint32_t n_elements, const float* dL_ddLdinput, const float* input, const void* dL_doutput, void* dL_dparams, void* dL_ddLdoutput, float* dL_dinput, const void* params) override {
 		// from: dL_ddLdinput
 		// to:   dL_ddLdoutput, dL_dparams
-		m_model->set_params((T*)params, (T*)params, (T*)params, (T*)dL_dparams);
+		m_model->set_params((T*)params, (T*)params, (T*)dL_dparams);
 
 		GPUMatrix<float, MatrixLayout::ColumnMajor> input_matrix((float*)input, m_model->input_width(), n_elements);
 		GPUMatrix<float, MatrixLayout::ColumnMajor> dL_ddLdinput_matrix((float*)dL_ddLdinput, m_model->input_width(), n_elements);
@@ -135,9 +135,9 @@ public:
 		return m_model->n_params();
 	}
 
-	void initialize_params(size_t seed, float* params_full_precision) override {
+	void initialize_params(size_t seed, float* params_full_precision, float scale) override {
 		pcg32 rng{seed};
-		m_model->initialize_params(rng, params_full_precision, nullptr, nullptr, nullptr, nullptr);
+		m_model->initialize_params(rng, params_full_precision, scale);
 	}
 
 	uint32_t n_output_dims() const override {

--- a/src/network.cu
+++ b/src/network.cu
@@ -139,7 +139,6 @@ Network<T>* create_network(const json& network) {
 	network["n_input_dims"], \
 	network["n_output_dims"], \
 	network.value("n_hidden_layers", 5u), \
-	network.value("feedback_alignment", false), \
 	string_to_activation(network.value("activation", "ReLU")), \
 	string_to_activation(network.value("output_activation", "None")),
 


### PR DESCRIPTION
Reduces risk of undefined behavior. Also makes two minor changes along the way:
- some components did not respect the `scale` parameter in `initialize_params`; this is now fixed
- got rid of `feedback_alignment`, which was rarely supported and did not work well in cases where it was