### PR TITLE
Fix case where no matching tinycudann_bindings was found

### DIFF
--- a/bindings/torch/tinycudann/modules.py
+++ b/bindings/torch/tinycudann/modules.py
@@ -19,6 +19,7 @@ system_compute_capability = major * 10 + minor
 
 # Try to import the highest compute capability version of tcnn that
 # we can find and is compatible with the system's compute capability.
+_C = None
 for cc in reversed(ALL_COMPUTE_CAPABILITIES):
 	if cc > system_compute_capability:
 		# incompatible


### PR DESCRIPTION
It may happen that `tinycudann_bindings` were compiled for a too modern architecture, e.g. for prebuilt docker images. In that case, no binding can be loaded and `_C` is never defined, such that the `EnvironmentError` is never reported. Defining `_C = None` should fix that code path and give a proper user-facing error message.

See also https://github.com/nerfstudio-project/nerfstudio/issues/1120 for a case where this happened.