### PR TITLE
Enable building kernels for multiple CUDA architectures in pytorch extension

### DIFF
--- a/bindings/torch/tinycudann/modules.py
+++ b/bindings/torch/tinycudann/modules.py
@@ -26,7 +26,7 @@ for cc in reversed(ALL_COMPUTE_CAPABILITIES):
 		continue
 
 	try:
-		_C = importlib.import_module(f"tinycudann_bindings_{cc}._C")
+		_C = importlib.import_module(f"tinycudann_bindings._{cc}_C")
 		break
 	except ModuleNotFoundError:
 		pass

--- a/bindings/torch/tinycudann/modules.py
+++ b/bindings/torch/tinycudann/modules.py
@@ -8,14 +8,35 @@
 
 import gc
 import importlib
+import warnings
+
 import torch
 
 ALL_COMPUTE_CAPABILITIES = [20, 21, 30, 35, 37, 50, 52, 53, 60, 61, 62, 70, 72, 75, 80, 86, 89, 90]
 
 if not torch.cuda.is_available():
 	raise EnvironmentError("Unknown compute capability. Ensure PyTorch with CUDA support is installed.")
-major, minor = torch.cuda.get_device_capability()
-system_compute_capability = major * 10 + minor
+
+def _get_device_compute_capability(idx):
+	major, minor = torch.cuda.get_device_capability(idx)
+	return major * 10 + minor
+
+def _get_system_compute_capability():
+	num_devices = torch.cuda.device_count()
+	device_capability = [_get_device_compute_capability(i) for i in range(num_devices)]
+	system_capability = min(device_capability)
+
+	if not all(cc == system_capability for cc in device_capability):
+		warnings.warn(
+			f"System has multiple GPUs with different compute capabilities: {device_capability}.\n"
+			f"Using compute capability {system_capability} for best compatibility.\n"
+			"This may result in suboptimal performance.")
+	return system_capability
+
+# Determine the capability of the system as the minimum of all
+# devices, ensuring that we have no runtime errors.
+system_compute_capability = _get_system_compute_capability()
+
 
 # Try to import the highest compute capability version of tcnn that
 # we can find and is compatible with the system's compute capability.


### PR DESCRIPTION
This PR enables the `pytorch` extension to build separate kernels for each requested architecture (making use of the multi-kernel loading ability), so that it is possible to build a single wheel which is compatible with multiple compute capabilities (including some with and some without support for fused MLP).

Explicitly, to build a wheel with the package compiled for each of the compute capability 70,75,80, one can execute:
```
TCNN_CUDA_ARCHITECTURES="70,75,80" python setup.py bdist_wheel
```

It also slightly changes the name of the generated python module to be `tinycudann_bindings._{version}_C` (i.e. all binding modules are submodules of `tinycudann_bindings`) to reduce the number of packages at the root level in `site-packages`.

P.S. Thanks for the great package!