### PR TITLE
[DOCS] Fixing `Leaky ReLU` to `LeakyReLU`.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -18,7 +18,7 @@ Activation functions are specified by string, e.g. as follows:
 The following activation functions are supported:
 - `"None"` (identity)
 - `"ReLU"`
-- `"Leaky ReLU"` (defined as `max(0, x) + 0.01 * min(0, x)`)
+- `"LeakyReLU"` (defined as `max(0, x) + 0.01 * min(0, x)`)
 - `"Exponential"`
 - `"Sine"`
 - `"Sigmoid"` (the logistic function)


### PR DESCRIPTION
The docs did not match the implementation in `network.cu` resulting in `RuntimeError: Invalid activation name: Leaky ReLU`. This diff makes the docs match the implementation.