### PR TITLE
Fix runtime error message in grid.h

### DIFF
--- a/include/tiny-cuda-nn/encodings/grid.h
+++ b/include/tiny-cuda-nn/encodings/grid.h
@@ -1178,7 +1178,7 @@ GridEncoding<T>* create_grid_encoding_templated_2(uint32_t n_dims_to_encode, con
 		// case 5: return new GridEncodingTemplated<T, 5, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
 		// case 6: return new GridEncodingTemplated<T, 6, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
 		// case 7: return new GridEncodingTemplated<T, 7, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
-		default: throw std::runtime_error{"GridEncoding: number of input dims must be 2 or 3."};
+		default: throw std::runtime_error{"GridEncoding: number of input dims must be 2, 3 or 4."};
 	}
 #undef TCNN_GRID_PARAMS
 }


### PR DESCRIPTION
The runtime error message in [grid.h](https://github.com/NVlabs/tiny-cuda-nn/blob/235d1fde956dc04966940f9d1bec66aa3bdb705a/include/tiny-cuda-nn/encodings/grid.h#L1181) is misleading, as it does not reflect the current state of supported input dimensions. This PR proposes to change the error text according to the source code.