### PR TITLE
Set cpp_standard=17 to allow compilation with torch >= 2.3

### DIFF
--- a/bindings/torch/setup.py
+++ b/bindings/torch/setup.py
@@ -77,7 +77,7 @@ if os.name == "nt":
 		# won't try to activate a developer command prompt a second time.
 		os.environ["DISTUTILS_USE_SDK"] = "1"
 
-cpp_standard = 14
+cpp_standard = 17
 
 # Get CUDA version and make sure the targeted compute capability is compatible
 if os.system("nvcc --version") == 0:


### PR DESCRIPTION
At some point torch started requiring --std=c++17 to be set.

Should this be conditional on torch version? 