### PR TITLE
Fix compile error for c++20

### DIFF
--- a/include/tiny-cuda-nn/common_host.h
+++ b/include/tiny-cuda-nn/common_host.h
@@ -56,7 +56,7 @@ void set_log_callback(const std::function<void(LogSeverity, const std::string&)>
 
 template <typename... Ts>
 void log(LogSeverity severity, const std::string& msg, Ts&&... args) {
-	log_callback()(severity, fmt::format(msg, std::forward<Ts>(args)...));
+	log_callback()(severity, fmt::format(fmt::runtime(msg), std::forward<Ts>(args)...));
 }
 
 template <typename... Ts> void log_info(const std::string& msg, Ts&&... args) { log(LogSeverity::Info, msg, std::forward<Ts>(args)...); }


### PR DESCRIPTION
See: https://stackoverflow.com/questions/76449282/workaround-for-dynamic-formatting-specs-with-fmt

fmt::format takes a consteval string when built with c++20 so wrap in fmt::runtime to allow this to compile when using c++20 or newer.