### PR TITLE
SiLU/Swish activation function

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -19,6 +19,7 @@ The following activation functions are supported:
 - `"None"` (identity)
 - `"ReLU"`
 - `"LeakyReLU"` (defined as `max(0, x) + 0.01 * min(0, x)`)
+- `"SiLU"` (defined as `x * sigmoid(x)`, also known as Swish)
 - `"Exponential"`
 - `"Sine"`
 - `"Sigmoid"` (the logistic function)

--- a/include/tiny-cuda-nn/common.h
+++ b/include/tiny-cuda-nn/common.h
@@ -131,6 +131,7 @@ using network_precision_t = float;
 enum class Activation {
 	ReLU,
 	LeakyReLU,
+	SiLU,
 	Exponential,
 	Sine,
 	Sigmoid,

--- a/src/common_host.cu
+++ b/src/common_host.cu
@@ -77,6 +77,8 @@ Activation string_to_activation(const std::string& activation_name) {
 		return Activation::ReLU;
 	} else if (equals_case_insensitive(activation_name, "LeakyReLU")) {
 		return Activation::LeakyReLU;
+	} else if (equals_case_insensitive(activation_name, "SiLU")) {
+		return Activation::SiLU;
 	} else if (equals_case_insensitive(activation_name, "Exponential")) {
 		return Activation::Exponential;
 	} else if (equals_case_insensitive(activation_name, "Sigmoid")) {
@@ -99,6 +101,7 @@ std::string to_string(Activation activation) {
 		case Activation::None: return "None";
 		case Activation::ReLU: return "ReLU";
 		case Activation::LeakyReLU: return "LeakyReLU";
+		case Activation::SiLU: return "SiLU";
 		case Activation::Exponential: return "Exponential";
 		case Activation::Sigmoid: return "Sigmoid";
 		case Activation::Sine: return "Sine";

--- a/src/cutlass_mlp.cu
+++ b/src/cutlass_mlp.cu
@@ -50,7 +50,7 @@ m_output_width{output_width},
 m_n_hidden_layers{n_hidden_layers},
 m_activation{activation},
 m_output_activation{output_activation},
-m_can_fuse_activation{activation != Activation::Sine}
+m_can_fuse_activation{activation != Activation::Sine && activation != Activation::SiLU}
 {
 	m_padded_output_width = next_multiple(m_output_width, REQUIRED_ALIGNMENT());
 
@@ -102,7 +102,7 @@ bool compute_layer(
 	if (!is_inference) {
 		// Never disallow fusing if the caller passes the same output and activation_output buffers... in that case,
 		// invertibility of the activation function may be ignored.
-		can_fuse_activation &= activation != Activation::Sine || &output == &activation_output;
+		can_fuse_activation &= (activation != Activation::Sine && activation != Activation::SiLU) || &output == &activation_output;
 	}
 
 	if (can_fuse_activation) {


### PR DESCRIPTION
SiLU is added as a non-fusable activation, similar to Sine.

The main motivation for this is to expand the range of supported activations, especially since SiLU is the default choice for some flow matching and diffusion model architectures.

I haven't been able to thoroughly test this, but, since it is a simple change, this PR should be fast to review.
I have only empirical good results from the sample code of fitting to einstein's image, shown below.

[einstein_training_silu.zip](https://github.com/user-attachments/files/21616360/einstein_training_silu.zip)


