### PR TITLE
Fix fmt compilation in C++20

### DIFF
--- a/include/tiny-cuda-nn/common_host.h
+++ b/include/tiny-cuda-nn/common_host.h
@@ -56,7 +56,7 @@ void set_log_callback(const std::function<void(LogSeverity, const std::string&)>
 
 template <typename... Ts>
 void log(LogSeverity severity, const std::string& msg, Ts&&... args) {
-	log_callback()(severity, fmt::format(msg, std::forward<Ts>(args)...));
+	log_callback()(severity, fmt::format(fmt::runtime(msg), std::forward<Ts>(args)...));
 }
 
 template <typename... Ts> void log_info(const std::string& msg, Ts&&... args) { log(LogSeverity::Info, msg, std::forward<Ts>(args)...); }
@@ -304,7 +304,7 @@ std::string dfmt(uint32_t indent, const std::string& format, Ts&&... args) {
 		}
 	}
 
-	return fmt::format(join(lines, "\n"), std::forward<Ts>(args)...);
+	return fmt::format(fmt::runtime(join(lines, "\n")), std::forward<Ts>(args)...);
 }
 
 std::string to_lower(std::string str);


### PR DESCRIPTION
I could not compile the library with C++20 on GCC14, upgrading fmt and using `fmt::runtime` however fixes the compilation errors.