### PR TITLE
Fix padding in OneBlob for SoA output

### DIFF
--- a/include/tiny-cuda-nn/encodings/oneblob.h
+++ b/include/tiny-cuda-nn/encodings/oneblob.h
@@ -223,7 +223,7 @@ public:
 			);
 
 			// Padding
-			parallel_for_gpu(stream, input.n() * m_n_to_pad, [out=output->data() + input.n() * m_n_dims_to_encode] __device__ (size_t i) {
+			parallel_for_gpu(stream, input.n() * m_n_to_pad, [out=output->data() + input.n() * m_n_output_dims] __device__ (size_t i) {
 				out[i] = (T)1.0f;
 			});
 		}


### PR DESCRIPTION
Hi @Tom94,

here's a quick fix for the padding in the OneBlob encoding. Previously, the encoding seems to overwrite some of its own data with padding when the output matrix is in SoA layout, because it starts at offset `n_dims_to_encode` rather than at `n_output_dims` (= `n_dims_to_encode * num_bins`). This PR should fix that :)


Greetings from Zürich,
– Alex