### PR TITLE
Feature/advertise build dependencies

### DIFF
--- a/bindings/torch/pyproject.toml
+++ b/bindings/torch/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=49.2.0",
     "wheel",
-    "torch>=1.7.0",
+    "torch>=2.7.0",
     "ninja",
     "packaging",
 ]

--- a/bindings/torch/pyproject.toml
+++ b/bindings/torch/pyproject.toml
@@ -12,6 +12,12 @@ name = "tinycudann"
 dynamic = ["version"]
 description = "tiny-cuda-nn extension for PyTorch"
 requires-python = ">=3.7"
+dependencies = [
+    "setuptools>=49.2.0",
+    "wheel",
+    "torch>=1.7.0",
+    "ninja"
+]
 license = {text = "BSD 3-Clause \"New\" or \"Revised\" License"}
 keywords = ["PyTorch", "cutlass", "machine learning", "neural networks", "CUDA"]
 authors = [

--- a/bindings/torch/pyproject.toml
+++ b/bindings/torch/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinycudann"
-dynamic = ["version", "readme"]
+dynamic = ["version"]
 readme = ""
 description = "tiny-cuda-nn extension for PyTorch"
 requires-python = ">=3.7"

--- a/bindings/torch/pyproject.toml
+++ b/bindings/torch/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "wheel",
     "torch>=1.7.0",
     "ninja",
+    "packaging",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/bindings/torch/pyproject.toml
+++ b/bindings/torch/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=49.2.0",
     "wheel",
-    "torch>=1.7",
+    "torch>=1.7.0",
     "ninja",
 ]
 build-backend = "setuptools.build_meta"
@@ -11,7 +11,6 @@ build-backend = "setuptools.build_meta"
 name = "tinycudann"
 dynamic = ["version"]
 description = "tiny-cuda-nn extension for PyTorch"
-readme = "../../README.md"
 requires-python = ">=3.7"
 license = {text = "BSD 3-Clause \"New\" or \"Revised\" License"}
 keywords = ["PyTorch", "cutlass", "machine learning", "neural networks", "CUDA"]
@@ -50,6 +49,3 @@ Repository = "https://github.com/nvlabs/tiny-cuda-nn"
 packages = ["tinycudann"]
 include-package-data = true
 zip-safe = false
-
-[tool.setuptools.dynamic]
-version = {attr = "setuptools.config.read_configuration('setup.py')"}

--- a/bindings/torch/pyproject.toml
+++ b/bindings/torch/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "torch>=1.7",
+    "ninja",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tinycudann"
+dynamic = ["version"]
+description = "tiny-cuda-nn extension for PyTorch"
+readme = "../../README.md"
+requires-python = ">=3.7"
+license = {text = "BSD 3-Clause \"New\" or \"Revised\" License"}
+keywords = ["PyTorch", "cutlass", "machine learning", "neural networks", "CUDA"]
+authors = [
+    {name = "Thomas Müller", email = "tmueller@nvidia.com"},
+    {name = "Jacob Munkberg", email = "jmunkberg@nvidia.com"},
+    {name = "Jon Hasselgren", email = "jhasselgren@nvidia.com"},
+    {name = "Or Perel", email = "operel@nvidia.com"},
+]
+maintainers = [
+    {name = "Thomas Müller", email = "tmueller@nvidia.com"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: GPU :: NVIDIA CUDA",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: C++",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Image Processing",
+]
+
+[project.urls]
+Homepage = "https://github.com/nvlabs/tiny-cuda-nn"
+Download = "https://github.com/nvlabs/tiny-cuda-nn"
+Repository = "https://github.com/nvlabs/tiny-cuda-nn"
+
+[tool.setuptools]
+packages = ["tinycudann"]
+include-package-data = true
+zip-safe = false
+
+[tool.setuptools.dynamic]
+version = {attr = "setuptools.config.read_configuration('setup.py')"}

--- a/bindings/torch/pyproject.toml
+++ b/bindings/torch/pyproject.toml
@@ -10,41 +10,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinycudann"
-dynamic = ["version"]
+dynamic = ["version", "readme"]
+readme = ""
 description = "tiny-cuda-nn extension for PyTorch"
 requires-python = ">=3.7"
+license = "BSD-3-Clause"
 dependencies = [
-    "setuptools>=49.2.0",
-    "wheel",
     "torch>=1.7.0",
-    "ninja"
-]
-license = {text = "BSD 3-Clause \"New\" or \"Revised\" License"}
-keywords = ["PyTorch", "cutlass", "machine learning", "neural networks", "CUDA"]
-authors = [
-    {name = "Thomas Müller", email = "tmueller@nvidia.com"},
-    {name = "Jacob Munkberg", email = "jmunkberg@nvidia.com"},
-    {name = "Jon Hasselgren", email = "jhasselgren@nvidia.com"},
-    {name = "Or Perel", email = "operel@nvidia.com"},
-]
-maintainers = [
-    {name = "Thomas Müller", email = "tmueller@nvidia.com"},
-]
-classifiers = [
-    "Development Status :: 4 - Beta",
-    "Environment :: GPU :: NVIDIA CUDA",
-    "License :: OSI Approved :: BSD License",
-    "Programming Language :: C++",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Topic :: Multimedia :: Graphics",
-    "Topic :: Scientific/Engineering :: Artificial Intelligence",
-    "Topic :: Scientific/Engineering :: Image Processing",
 ]
 
 [project.urls]


### PR DESCRIPTION
Hi,

To make installation of this great package easier from other python projects, I added a minimal pyproject.toml file to advertise build dependency following PEP517. 

It allows, to add tiny-cuda-nn as part of dependency table of another project and specify no build isolation to have it installed in one go (with pixi install for example).

I don't know which tests I should do to make more verification to make this "mergeable".

Best regards,
Julien Stanguennec