### PR TITLE
Add configurable bounds for hash-grid input dimensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ set(TCNN_EXTERNAL_FMT "" CACHE STRING "If non-empty, the `fmt` target is supplie
 
 set(TCNN_CUDA_ARCHITECTURES "" CACHE STRING "Build tiny-cuda-nn for a specific GPU architecture.")
 option(TCNN_LINK_CUDA "Link tiny-cuda-nn to CUDA libraries?" ON)
+set(TCNN_HASH_MIN_DIM 2 CACHE STRING "Lowest hash-grid dimensionality compiled into the library (1-7).")
+set(TCNN_HASH_MAX_DIM 4 CACHE STRING "Highest hash-grid dimensionality compiled into the library (1-7).")
 
 ###############################################################################
 # Build type and C++ compiler setup
@@ -217,11 +219,37 @@ else()
     message(STATUS "TCNN_HALF_PRECISION: OFF")
 endif()
 
+if (NOT TCNN_HASH_MIN_DIM MATCHES "^[0-9]+$")
+	message(FATAL_ERROR "TCNN_HASH_MIN_DIM must be an integer in the range [1, 7].")
+endif()
+
+if (NOT TCNN_HASH_MAX_DIM MATCHES "^[0-9]+$")
+	message(FATAL_ERROR "TCNN_HASH_MAX_DIM must be an integer in the range [1, 7].")
+endif()
+
+if (TCNN_HASH_MIN_DIM LESS 1 OR TCNN_HASH_MIN_DIM GREATER 7)
+	message(FATAL_ERROR "TCNN_HASH_MIN_DIM=${TCNN_HASH_MIN_DIM} is out of range. Valid values are 1 through 7.")
+endif()
+
+if (TCNN_HASH_MAX_DIM LESS 1 OR TCNN_HASH_MAX_DIM GREATER 7)
+	message(FATAL_ERROR "TCNN_HASH_MAX_DIM=${TCNN_HASH_MAX_DIM} is out of range. Valid values are 1 through 7.")
+endif()
+
+if (TCNN_HASH_MIN_DIM GREATER TCNN_HASH_MAX_DIM)
+	message(FATAL_ERROR "TCNN_HASH_MIN_DIM=${TCNN_HASH_MIN_DIM} must not exceed TCNN_HASH_MAX_DIM=${TCNN_HASH_MAX_DIM}.")
+endif()
+
+list(APPEND TCNN_DEFINITIONS -DTCNN_HASH_MIN_DIM=${TCNN_HASH_MIN_DIM})
+list(APPEND TCNN_DEFINITIONS -DTCNN_HASH_MAX_DIM=${TCNN_HASH_MAX_DIM})
+message(STATUS "TCNN hash-grid dimensions: ${TCNN_HASH_MIN_DIM}-${TCNN_HASH_MAX_DIM}")
+
 message(STATUS "Targeting CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 if (TCNN_HAS_PARENT)
 	set(TCNN_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES} PARENT_SCOPE)
 	set(TCNN_CUDA_VERSION ${CUDA_VERSION} PARENT_SCOPE)
 	set(TCNN_HALF_PRECISION ${TCNN_HALF_PRECISION} PARENT_SCOPE)
+	set(TCNN_HASH_MIN_DIM ${TCNN_HASH_MIN_DIM} PARENT_SCOPE)
+	set(TCNN_HASH_MAX_DIM ${TCNN_HASH_MAX_DIM} PARENT_SCOPE)
 endif()
 
 if (MIN_GPU_ARCH LESS_EQUAL 70)

--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ tiny-cuda-nn$ cmake . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
 tiny-cuda-nn$ cmake --build build --config RelWithDebInfo -j
 ```
 
+If you need hash-grid support outside the default 2D-4D range, override the compiled bounds at configure time. For example, to enable 5D hash grids:
+```sh
+tiny-cuda-nn$ cmake . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTCNN_HASH_MAX_DIM=5
+```
+
 If compilation fails inexplicably or takes longer than an hour, you might be running out of memory. Try running the above command without `-j` in that case.
 
 
@@ -232,6 +237,18 @@ Example:
 # Linux / macOS (Disable FP16)
 export TCNN_HALF_PRECISION=0
 pip install git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch
+```
+
+Hash-grid support in the PyTorch extension defaults to 2D-4D. To compile 5D hash grids, set the bounds before installation:
+```sh
+# Linux / macOS
+export TCNN_HASH_MAX_DIM=5
+pip install git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch
+```
+
+For local installs through `setup.py`, the same override is also available as command-line arguments:
+```sh
+tiny-cuda-nn/bindings/torch$ python setup.py install --hash-max-dim=5
 ```
 
 Upon success, you can use __tiny-cuda-nn__ models as in the following example:

--- a/bindings/torch/setup.py
+++ b/bindings/torch/setup.py
@@ -33,6 +33,41 @@ def max_supported_compute_capability(cuda_version):
 	else:
 		return 120
 
+def pop_arg_value(name):
+	prefix = f"{name}="
+	for i, arg in enumerate(sys.argv):
+		if arg.startswith(prefix):
+			value = arg[len(prefix):]
+			del sys.argv[i]
+			return value
+
+	if name in sys.argv:
+		index = sys.argv.index(name)
+		if index + 1 >= len(sys.argv):
+			raise RuntimeError(f"Missing value for {name}")
+
+		value = sys.argv[index + 1]
+		del sys.argv[index:index + 2]
+		return value
+
+	return None
+
+def get_int_setting(arg_name, env_name, default):
+	arg_value = pop_arg_value(arg_name)
+	env_value = os.environ.get(env_name)
+
+	if arg_value is not None and env_value is not None:
+		raise RuntimeError(f"Specify only one of {arg_name} or {env_name}.")
+
+	value = env_value if env_value is not None else arg_value
+	if value is None:
+		return default, "default"
+
+	try:
+		return int(value), env_name if env_value is not None else arg_name
+	except ValueError as exc:
+		raise RuntimeError(f"{env_name} must be an integer.") from exc
+
 # Find version of tinycudann by scraping CMakeLists.txt
 with open(os.path.join(ROOT_DIR, "CMakeLists.txt"), "r") as cmakelists:
 	for line in cmakelists.readlines():
@@ -59,6 +94,23 @@ if "--no-networks" in sys.argv:
 	include_networks = False
 	sys.argv.remove("--no-networks")
 	print("Building >> without << neural networks (just the input encodings)")
+
+hash_min_dim, hash_min_dim_source = get_int_setting("--hash-min-dim", "TCNN_HASH_MIN_DIM", 2)
+hash_max_dim, hash_max_dim_source = get_int_setting("--hash-max-dim", "TCNN_HASH_MAX_DIM", 4)
+
+if hash_min_dim < 1 or hash_min_dim > 7:
+	raise RuntimeError(f"TCNN_HASH_MIN_DIM={hash_min_dim} is out of range. Valid values are 1 through 7.")
+
+if hash_max_dim < 1 or hash_max_dim > 7:
+	raise RuntimeError(f"TCNN_HASH_MAX_DIM={hash_max_dim} is out of range. Valid values are 1 through 7.")
+
+if hash_min_dim > hash_max_dim:
+	raise RuntimeError(f"TCNN_HASH_MIN_DIM={hash_min_dim} must not exceed TCNN_HASH_MAX_DIM={hash_max_dim}.")
+
+if hash_min_dim_source != "default" or hash_max_dim_source != "default":
+	print(f"Overriding hash-grid support to dimensions {hash_min_dim}-{hash_max_dim}")
+else:
+	print(f"Compiling hash-grid support for dimensions {hash_min_dim}-{hash_max_dim}")
 
 if os.name == "nt":
 	def find_cl_path():
@@ -144,6 +196,8 @@ base_definitions = [
 	"-DTCNN_PARAMS_UNALIGNED",
 	"-DTCNN_RTC",
 	"-DTCNN_RTC_USE_FAST_MATH",
+	f"-DTCNN_HASH_MIN_DIM={hash_min_dim}",
+	f"-DTCNN_HASH_MAX_DIM={hash_max_dim}",
 ]
 
 if "TCNN_HALF_PRECISION" in os.environ:

--- a/include/tiny-cuda-nn/common.h
+++ b/include/tiny-cuda-nn/common.h
@@ -81,15 +81,29 @@
 #define TCNN_MIN_GPU_ARCH 75
 #endif
 
+#ifndef TCNN_HASH_MIN_DIM
+#define TCNN_HASH_MIN_DIM 2
+#endif
+
+#ifndef TCNN_HASH_MAX_DIM
+#define TCNN_HASH_MAX_DIM 4
+#endif
+
 #include <tiny-cuda-nn/vec.h>
 
 #if defined(__CUDA_ARCH__)
 static_assert(__CUDA_ARCH__ >= TCNN_MIN_GPU_ARCH * 10, "MIN_GPU_ARCH=" STR(TCNN_MIN_GPU_ARCH) "0 must bound __CUDA_ARCH__=" STR(__CUDA_ARCH__) " from below, but doesn't.");
 #endif
 
+static_assert(TCNN_HASH_MIN_DIM >= 1 && TCNN_HASH_MIN_DIM <= 7, "TCNN_HASH_MIN_DIM must be in the range [1, 7].");
+static_assert(TCNN_HASH_MAX_DIM >= 1 && TCNN_HASH_MAX_DIM <= 7, "TCNN_HASH_MAX_DIM must be in the range [1, 7].");
+static_assert(TCNN_HASH_MIN_DIM <= TCNN_HASH_MAX_DIM, "TCNN_HASH_MIN_DIM must not exceed TCNN_HASH_MAX_DIM.");
+
 namespace tcnn {
 
 static constexpr uint32_t MIN_GPU_ARCH = TCNN_MIN_GPU_ARCH;
+static constexpr uint32_t HASH_GRID_MIN_DIM = TCNN_HASH_MIN_DIM;
+static constexpr uint32_t HASH_GRID_MAX_DIM = TCNN_HASH_MAX_DIM;
 
 // When TCNN managed its model parameters, they are always aligned,
 // which yields performance benefits in practice. However, parameters

--- a/include/tiny-cuda-nn/encodings/grid.h
+++ b/include/tiny-cuda-nn/encodings/grid.h
@@ -1754,16 +1754,29 @@ create_grid_encoding_templated_2(uint32_t n_dims_to_encode, const json& encoding
 	grid_type, \
 	fixed_point_pos,
 
-	// If higher-dimensional hash encodings are desired, corresponding switch cases can be added
 	switch (n_dims_to_encode) {
-		// case 1: return new GridEncodingTemplated<T, 1, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
+#if TCNN_HASH_MIN_DIM <= 1 && TCNN_HASH_MAX_DIM >= 1
+		case 1: return new GridEncodingTemplated<T, 1, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
+#endif
+#if TCNN_HASH_MIN_DIM <= 2 && TCNN_HASH_MAX_DIM >= 2
 		case 2: return new GridEncodingTemplated<T, 2, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
+#endif
+#if TCNN_HASH_MIN_DIM <= 3 && TCNN_HASH_MAX_DIM >= 3
 		case 3: return new GridEncodingTemplated<T, 3, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
+#endif
+#if TCNN_HASH_MIN_DIM <= 4 && TCNN_HASH_MAX_DIM >= 4
 		case 4: return new GridEncodingTemplated<T, 4, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
-		// case 5: return new GridEncodingTemplated<T, 5, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
-		// case 6: return new GridEncodingTemplated<T, 6, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
-		// case 7: return new GridEncodingTemplated<T, 7, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
-		default: throw std::runtime_error{"GridEncoding: number of input dims must be 2 or 3."};
+#endif
+#if TCNN_HASH_MIN_DIM <= 5 && TCNN_HASH_MAX_DIM >= 5
+		case 5: return new GridEncodingTemplated<T, 5, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
+#endif
+#if TCNN_HASH_MIN_DIM <= 6 && TCNN_HASH_MAX_DIM >= 6
+		case 6: return new GridEncodingTemplated<T, 6, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
+#endif
+#if TCNN_HASH_MIN_DIM <= 7 && TCNN_HASH_MAX_DIM >= 7
+		case 7: return new GridEncodingTemplated<T, 7, N_FEATURES_PER_LEVEL, HASH_TYPE>{ TCNN_GRID_PARAMS };
+#endif
+		default: throw std::runtime_error{"GridEncoding: number of input dims must be between " STR(TCNN_HASH_MIN_DIM) " and " STR(TCNN_HASH_MAX_DIM) " for this build."};
 	}
 #undef TCNN_GRID_PARAMS
 }

--- a/tests/test_grid.cu
+++ b/tests/test_grid.cu
@@ -90,3 +90,33 @@ TEST_CASE("GridEncoding sanity checks", "[encoding]") {
 	std::vector<float> result_host(output.n_elements());
 	CUDA_CHECK_THROW(cudaMemcpy(result_host.data(), output.data(), output.n_bytes(), cudaMemcpyDeviceToHost));
 }
+
+TEST_CASE("GridEncoding respects configured hash-grid dimension bounds", "[encoding]") {
+	tcnn_test_setup();
+
+	const char* config = R"({
+		"otype": "HashGrid",
+		"base_resolution": 16,
+		"log2_hashmap_size": 14,
+		"n_features_per_level": 2,
+		"n_levels": 4,
+		"per_level_scale": 1.5
+	})";
+
+	nlohmann::json config_json = nlohmann::json::parse(config);
+
+	std::unique_ptr<MultiLevelEncoding<float>> supported{
+		dynamic_cast<MultiLevelEncoding<float>*>(create_encoding<float>(TCNN_HASH_MAX_DIM, config_json))
+	};
+
+	REQUIRE(supported);
+	REQUIRE(supported->n_pos_dims() == TCNN_HASH_MAX_DIM);
+
+#if TCNN_HASH_MIN_DIM > 1
+	REQUIRE_THROWS_AS(create_encoding<float>(TCNN_HASH_MIN_DIM - 1, config_json), std::runtime_error);
+#endif
+
+#if TCNN_HASH_MAX_DIM < 7
+	REQUIRE_THROWS_AS(create_encoding<float>(TCNN_HASH_MAX_DIM + 1, config_json), std::runtime_error);
+#endif
+}


### PR DESCRIPTION
﻿## Summary
- add configurable `TCNN_HASH_MIN_DIM` and `TCNN_HASH_MAX_DIM` build options for hash grids
- thread the same dimension bounds through CMake and the PyTorch extension build
- add test coverage and README usage notes for enabling 5D hash grids

## Why
Issue #422 asks for 5D grid support. The current hash-grid dispatch is hard-coded to a narrow range of input dimensions, so enabling 5D grids requires rebuilding the library. This change makes the supported hash-grid dimension range explicit and configurable at build time while preserving the existing defaults.

## Validation
- `python -m py_compile bindings/torch/setup.py`
- `cmake -S . -B build-hash-dim-check -G Ninja -DTCNN_BUILD_TESTS=1 -DTCNN_HASH_MAX_DIM=5`
- `cmake --build build-hash-dim-check --target test_grid`
- `ctest --output-on-failure -V -R test_grid`

Closes #422.
